### PR TITLE
Fix bulk upload failure status tracking

### DIFF
--- a/src/components/BulkUpload.tsx
+++ b/src/components/BulkUpload.tsx
@@ -131,7 +131,7 @@ export default function BulkUpload() {
         .update({
           records_success: successCount,
           records_failed: failedCount,
-          status: failedCount === 0 ? 'completed' : 'completed',
+          status: failedCount === 0 ? 'completed' : 'failed',
           error_log: errors
         })
         .eq('id', upload.id);


### PR DESCRIPTION
## Summary
- mark bulk upload history entries as `failed` when any records fail during processing

## Testing
- not run (reason: not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2b5f55db48329b2b504047088a1f7