### PR TITLE
Add metadata to offline sync queue entries

### DIFF
--- a/src/components/SyncQueue.tsx
+++ b/src/components/SyncQueue.tsx
@@ -77,6 +77,9 @@ export default function SyncQueue() {
           extracted_pack_size: entry.extractedData.pack_size,
           actual_quantity: entry.quantity,
           unit_type: entry.unitType,
+          branch: entry.branch,
+          location: entry.location,
+          expiry_date: entry.expiryDate || null,
           synced: true
         });
 
@@ -187,6 +190,15 @@ export default function SyncQueue() {
                   </p>
                   <p className="text-sm text-gray-600">
                     Quantity: {entry.quantity} {entry.unitType}
+                  </p>
+                  <p className="text-sm text-gray-600">
+                    Branch: {entry.branch}
+                  </p>
+                  <p className="text-sm text-gray-600">
+                    Location: {entry.location}
+                  </p>
+                  <p className="text-sm text-gray-600">
+                    Expiry Date: {entry.expiryDate || 'N/A'}
                   </p>
                   <p className="text-xs text-gray-500 mt-1">
                     Added: {new Date(entry.timestamp).toLocaleString()}

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -16,6 +16,9 @@ interface SerializedQueuedEntry {
   };
   quantity: number;
   unitType: 'pallet' | 'case' | 'layer';
+  branch: string;
+  location: string;
+  expiryDate: string | null;
   timestamp: number;
 }
 
@@ -29,6 +32,9 @@ export type QueueEntryInput = {
   extractedData: SerializedQueuedEntry['extractedData'];
   quantity: number;
   unitType: SerializedQueuedEntry['unitType'];
+  branch: string;
+  location: string;
+  expiryDate: SerializedQueuedEntry['expiryDate'];
 };
 
 const QUEUE_KEY = 'stocktake_sync_queue';
@@ -47,6 +53,9 @@ export function addToQueue(entry: QueueEntryInput): string {
     extractedData: entry.extractedData,
     quantity: entry.quantity,
     unitType: entry.unitType,
+    branch: entry.branch,
+    location: entry.location,
+    expiryDate: entry.expiryDate ?? null,
     timestamp: Date.now()
   };
 


### PR DESCRIPTION
## Summary
- extend the offline queue serialization to include branch, location, and expiry metadata
- surface the additional metadata in the sync queue list and send it with Supabase inserts
- update the stocktake offline fallback to persist the expanded metadata when queueing entries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2d33ccf0083299e8ca58e64f55283