### PR TITLE
Add Supabase helpers for product pallet lookups

### DIFF
--- a/src/lib/productPalletView.ts
+++ b/src/lib/productPalletView.ts
@@ -1,0 +1,15 @@
+import { supabase } from './supabase';
+
+const baseQuery = () => supabase.from('product_pallet_view').select('*');
+
+export function getByCaseBarcode(barcode: string) {
+  return baseQuery().eq('case_barcode', barcode).maybeSingle();
+}
+
+export function getByUnitBarcode(barcode: string) {
+  return baseQuery().eq('unit_barcode', barcode).maybeSingle();
+}
+
+export function getByStockCode(code: string) {
+  return baseQuery().eq('stock_code', code).maybeSingle();
+}


### PR DESCRIPTION
## Summary
- add a reusable helper for querying the `product_pallet_view`
- expose functions to fetch pallet records by case barcode, unit barcode, or stock code

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e419b209248329bbe9cb965cb5df3a