### PR TITLE
Implement updated counting workflows with recounts and exports

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,17 @@
-import { useState } from 'react';
-import { Camera, FileText, Users, LogOut, Menu, X, Upload, FileSpreadsheet, Package } from 'lucide-react';
+import { useState, type ReactNode } from 'react';
+import {
+  Camera,
+  ClipboardList,
+  Download,
+  FileSpreadsheet,
+  FileText,
+  LogOut,
+  Menu,
+  Package,
+  Upload,
+  Users,
+  X
+} from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import StocktakeEntry from './StocktakeEntry';
 import VarianceReports from './VarianceReports';
@@ -7,8 +19,10 @@ import UserManagement from './UserManagement';
 import SyncQueue from './SyncQueue';
 import BulkUpload from './BulkUpload';
 import PalletConfiguration from './PalletConfiguration';
+import Recounts from './Recounts';
+import ExportCounts from './ExportCounts';
 
-type Page = 'stocktake' | 'variance' | 'users' | 'sync' | 'bulk' | 'pallet';
+type Page = 'stocktake' | 'recounts' | 'variance' | 'users' | 'sync' | 'bulk' | 'pallet' | 'export';
 
 export default function Dashboard() {
   const { profile, signOut } = useAuth();
@@ -28,11 +42,13 @@ export default function Dashboard() {
 
     switch (page) {
       case 'stocktake':
+      case 'recounts':
       case 'sync':
         return true;
       case 'bulk':
       case 'variance':
       case 'pallet':
+      case 'export':
         return ['manager', 'admin'].includes(profile.role);
       case 'users':
         return profile.role === 'admin';
@@ -45,6 +61,8 @@ export default function Dashboard() {
     switch (currentPage) {
       case 'stocktake':
         return <StocktakeEntry />;
+      case 'recounts':
+        return <Recounts />;
       case 'bulk':
         return <BulkUpload />;
       case 'pallet':
@@ -55,9 +73,60 @@ export default function Dashboard() {
         return <UserManagement />;
       case 'sync':
         return <SyncQueue />;
+      case 'export':
+        return <ExportCounts />;
       default:
         return <StocktakeEntry />;
     }
+  }
+
+  function NavButton({
+    page,
+    label,
+    icon
+  }: {
+    page: Page;
+    label: string;
+    icon: ReactNode;
+  }) {
+    const isActive = currentPage === page;
+    return (
+      <button
+        onClick={() => setCurrentPage(page)}
+        className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all ${
+          isActive ? 'bg-blue-600 text-white' : 'text-gray-700 hover:bg-gray-100'
+        }`}
+      >
+        {icon}
+        {label}
+      </button>
+    );
+  }
+
+  function MobileNavButton({
+    page,
+    label,
+    icon
+  }: {
+    page: Page;
+    label: string;
+    icon: ReactNode;
+  }) {
+    const isActive = currentPage === page;
+    return (
+      <button
+        onClick={() => {
+          setCurrentPage(page);
+          setMenuOpen(false);
+        }}
+        className={`w-full flex items-center gap-2 px-4 py-3 rounded-lg font-medium transition-all ${
+          isActive ? 'bg-blue-600 text-white' : 'text-gray-700 hover:bg-gray-100'
+        }`}
+      >
+        {icon}
+        {label}
+      </button>
+    );
   }
 
   return (
@@ -73,84 +142,28 @@ export default function Dashboard() {
             </div>
 
             <div className="hidden md:flex items-center gap-6">
-              <button
-                onClick={() => setCurrentPage('stocktake')}
-                className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all ${
-                  currentPage === 'stocktake'
-                    ? 'bg-blue-600 text-white'
-                    : 'text-gray-700 hover:bg-gray-100'
-                }`}
-              >
-                <Camera className="w-4 h-4" />
-                Stocktake
-              </button>
-
-              <button
-                onClick={() => setCurrentPage('sync')}
-                className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all ${
-                  currentPage === 'sync'
-                    ? 'bg-blue-600 text-white'
-                    : 'text-gray-700 hover:bg-gray-100'
-                }`}
-              >
-                <Upload className="w-4 h-4" />
-                Sync Queue
-              </button>
+              <NavButton page="stocktake" label="Stocktake" icon={<Camera className="w-4 h-4" />} />
+              <NavButton page="recounts" label="Recounts" icon={<ClipboardList className="w-4 h-4" />} />
+              <NavButton page="sync" label="Sync Queue" icon={<Upload className="w-4 h-4" />} />
 
               {canAccessPage('bulk') && (
-                <button
-                  onClick={() => setCurrentPage('bulk')}
-                  className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all ${
-                    currentPage === 'bulk'
-                      ? 'bg-blue-600 text-white'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  <FileSpreadsheet className="w-4 h-4" />
-                  Bulk Upload
-                </button>
+                <NavButton page="bulk" label="Bulk Upload" icon={<FileSpreadsheet className="w-4 h-4" />} />
               )}
 
               {canAccessPage('pallet') && (
-                <button
-                  onClick={() => setCurrentPage('pallet')}
-                  className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all ${
-                    currentPage === 'pallet'
-                      ? 'bg-blue-600 text-white'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  <Package className="w-4 h-4" />
-                  Pallet Config
-                </button>
+                <NavButton page="pallet" label="Pallet Config" icon={<Package className="w-4 h-4" />} />
               )}
 
               {canAccessPage('variance') && (
-                <button
-                  onClick={() => setCurrentPage('variance')}
-                  className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all ${
-                    currentPage === 'variance'
-                      ? 'bg-blue-600 text-white'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  <FileText className="w-4 h-4" />
-                  Variance
-                </button>
+                <NavButton page="variance" label="Variance" icon={<FileText className="w-4 h-4" />} />
               )}
 
               {canAccessPage('users') && (
-                <button
-                  onClick={() => setCurrentPage('users')}
-                  className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all ${
-                    currentPage === 'users'
-                      ? 'bg-blue-600 text-white'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  <Users className="w-4 h-4" />
-                  Users
-                </button>
+                <NavButton page="users" label="Users" icon={<Users className="w-4 h-4" />} />
+              )}
+
+              {canAccessPage('export') && (
+                <NavButton page="export" label="Export" icon={<Download className="w-4 h-4" />} />
               )}
 
               <div className="flex items-center gap-3 ml-4 pl-4 border-l border-gray-200">
@@ -180,102 +193,28 @@ export default function Dashboard() {
         {menuOpen && (
           <div className="md:hidden border-t border-gray-200 bg-white">
             <div className="px-4 py-3 space-y-2">
-              <button
-                onClick={() => {
-                  setCurrentPage('stocktake');
-                  setMenuOpen(false);
-                }}
-                className={`w-full flex items-center gap-2 px-4 py-3 rounded-lg font-medium transition-all ${
-                  currentPage === 'stocktake'
-                    ? 'bg-blue-600 text-white'
-                    : 'text-gray-700 hover:bg-gray-100'
-                }`}
-              >
-                <Camera className="w-5 h-5" />
-                Stocktake
-              </button>
-
-              <button
-                onClick={() => {
-                  setCurrentPage('sync');
-                  setMenuOpen(false);
-                }}
-                className={`w-full flex items-center gap-2 px-4 py-3 rounded-lg font-medium transition-all ${
-                  currentPage === 'sync'
-                    ? 'bg-blue-600 text-white'
-                    : 'text-gray-700 hover:bg-gray-100'
-                }`}
-              >
-                <Upload className="w-5 h-5" />
-                Sync Queue
-              </button>
+              <MobileNavButton page="stocktake" label="Stocktake" icon={<Camera className="w-5 h-5" />} />
+              <MobileNavButton page="recounts" label="Recounts" icon={<ClipboardList className="w-5 h-5" />} />
+              <MobileNavButton page="sync" label="Sync Queue" icon={<Upload className="w-5 h-5" />} />
 
               {canAccessPage('bulk') && (
-                <button
-                  onClick={() => {
-                    setCurrentPage('bulk');
-                    setMenuOpen(false);
-                  }}
-                  className={`w-full flex items-center gap-2 px-4 py-3 rounded-lg font-medium transition-all ${
-                    currentPage === 'bulk'
-                      ? 'bg-blue-600 text-white'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  <FileSpreadsheet className="w-5 h-5" />
-                  Bulk Upload
-                </button>
+                <MobileNavButton page="bulk" label="Bulk Upload" icon={<FileSpreadsheet className="w-5 h-5" />} />
               )}
 
               {canAccessPage('pallet') && (
-                <button
-                  onClick={() => {
-                    setCurrentPage('pallet');
-                    setMenuOpen(false);
-                  }}
-                  className={`w-full flex items-center gap-2 px-4 py-3 rounded-lg font-medium transition-all ${
-                    currentPage === 'pallet'
-                      ? 'bg-blue-600 text-white'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  <Package className="w-5 h-5" />
-                  Pallet Configuration
-                </button>
+                <MobileNavButton page="pallet" label="Pallet Config" icon={<Package className="w-5 h-5" />} />
               )}
 
               {canAccessPage('variance') && (
-                <button
-                  onClick={() => {
-                    setCurrentPage('variance');
-                    setMenuOpen(false);
-                  }}
-                  className={`w-full flex items-center gap-2 px-4 py-3 rounded-lg font-medium transition-all ${
-                    currentPage === 'variance'
-                      ? 'bg-blue-600 text-white'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  <FileText className="w-5 h-5" />
-                  Variance Reports
-                </button>
+                <MobileNavButton page="variance" label="Variance" icon={<FileText className="w-5 h-5" />} />
               )}
 
               {canAccessPage('users') && (
-                <button
-                  onClick={() => {
-                    setCurrentPage('users');
-                    setMenuOpen(false);
-                  }}
-                  className={`w-full flex items-center gap-2 px-4 py-3 rounded-lg font-medium transition-all ${
-                    currentPage === 'users'
-                      ? 'bg-blue-600 text-white'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  <Users className="w-5 h-5" />
-                  User Management
-                </button>
+                <MobileNavButton page="users" label="Users" icon={<Users className="w-5 h-5" />} />
+              )}
+
+              {canAccessPage('export') && (
+                <MobileNavButton page="export" label="Export" icon={<Download className="w-5 h-5" />} />
               )}
 
               <div className="pt-3 border-t border-gray-200">
@@ -296,9 +235,7 @@ export default function Dashboard() {
         )}
       </nav>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {renderPage()}
-      </main>
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">{renderPage()}</main>
     </div>
   );
 }

--- a/src/components/ExportCounts.tsx
+++ b/src/components/ExportCounts.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react';
+import { Download, Loader2 } from 'lucide-react';
+import { supabase } from '../lib/supabase';
+
+interface EventOption {
+  id: string;
+  name: string;
+}
+
+interface WarehouseOption {
+  id: string;
+  name: string;
+}
+
+export default function ExportCounts() {
+  const [events, setEvents] = useState<EventOption[]>([]);
+  const [warehouses, setWarehouses] = useState<WarehouseOption[]>([]);
+  const [selectedEvent, setSelectedEvent] = useState('');
+  const [selectedWarehouse, setSelectedWarehouse] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [downloading, setDownloading] = useState(false);
+  const [error, setError] = useState('');
+  const [notice, setNotice] = useState('');
+
+  useEffect(() => {
+    async function loadOptions() {
+      setLoading(true);
+      setError('');
+      try {
+        const [{ data: eventData, error: eventError }, { data: warehouseData, error: warehouseError }] = await Promise.all([
+          supabase.from('stocktake_events').select('id, name').order('name'),
+          supabase.from('warehouses').select('id, name').order('name')
+        ]);
+
+        if (eventError) throw eventError;
+        if (warehouseError) throw warehouseError;
+
+        setEvents(eventData ?? []);
+        setWarehouses(warehouseData ?? []);
+      } catch (err) {
+        console.error('Error loading export options:', err);
+        setError(err instanceof Error ? err.message : 'Failed to load export filters.');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadOptions();
+  }, []);
+
+  async function handleDownload() {
+    setDownloading(true);
+    setError('');
+    setNotice('');
+
+    try {
+      const {
+        data: { session }
+      } = await supabase.auth.getSession();
+
+      if (!session?.access_token) {
+        throw new Error('Unable to authenticate download request.');
+      }
+
+      const params = new URLSearchParams();
+      if (selectedEvent) {
+        params.append('event_id', selectedEvent);
+      }
+      if (selectedWarehouse) {
+        params.append('warehouse_id', selectedWarehouse);
+      }
+
+      const response = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/export-counts?${params.toString()}`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${session.access_token}`
+          }
+        }
+      );
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Failed to download export.');
+      }
+
+      const blob = await response.blob();
+      const downloadUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = downloadUrl;
+      link.download = `stock-counts-${Date.now()}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(downloadUrl);
+
+      setNotice('Export started. Check your downloads for the CSV file.');
+    } catch (err) {
+      console.error('Error exporting counts:', err);
+      setError(err instanceof Error ? err.message : 'Failed to export counts.');
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="bg-white rounded-xl shadow-lg p-6 space-y-6">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <Download className="h-6 w-6 text-blue-600" />
+            Export Counts
+          </h2>
+          <p className="text-gray-600 text-sm mt-1">
+            Download the captured counts for auditing or reconciliation. Choose an event and warehouse to filter your export.
+          </p>
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+        )}
+
+        {notice && (
+          <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">{notice}</div>
+        )}
+
+        {loading ? (
+          <div className="flex flex-col items-center justify-center gap-3 py-12 text-gray-600">
+            <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+            Loading export filters...
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <label className="flex flex-col gap-2 text-sm font-medium text-gray-700">
+              Event
+              <select
+                value={selectedEvent}
+                onChange={(event) => setSelectedEvent(event.target.value)}
+                className="rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              >
+                <option value="">All events</option>
+                {events.map((event) => (
+                  <option key={event.id} value={event.id}>
+                    {event.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-2 text-sm font-medium text-gray-700">
+              Warehouse
+              <select
+                value={selectedWarehouse}
+                onChange={(event) => setSelectedWarehouse(event.target.value)}
+                className="rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              >
+                <option value="">All warehouses</option>
+                {warehouses.map((warehouse) => (
+                  <option key={warehouse.id} value={warehouse.id}>
+                    {warehouse.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <button
+              type="button"
+              onClick={handleDownload}
+              disabled={downloading}
+              className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-3 font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+            >
+              {downloading ? <Loader2 className="h-5 w-5 animate-spin" /> : <Download className="h-5 w-5" />}
+              {downloading ? 'Preparing export…' : 'Download CSV'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Recounts.tsx
+++ b/src/components/Recounts.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ClipboardList, Loader2, RefreshCcw, Search } from 'lucide-react';
+import StocktakeEntry from './StocktakeEntry';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+
+interface RecountTask {
+  id: string;
+  stock_code: string;
+  lot_number: string;
+  description?: string | null;
+  warehouse?: string | null;
+  location?: string | null;
+  created_at?: string;
+}
+
+export default function Recounts() {
+  const { user } = useAuth();
+  const [tasks, setTasks] = useState<RecountTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedTask, setSelectedTask] = useState<RecountTask | null>(null);
+  const [submittingTaskId, setSubmittingTaskId] = useState<string | null>(null);
+  const [error, setError] = useState('');
+
+  const loadTasks = useCallback(async () => {
+    if (!user) return;
+    setLoading(true);
+    setError('');
+    try {
+      const { data, error: queryError } = await supabase
+        .from('recount_tasks')
+        .select('*')
+        .eq('assigned_to', user.id)
+        .eq('status', 'open')
+        .order('created_at', { ascending: true });
+
+      if (queryError) throw queryError;
+      setTasks(data ?? []);
+      if (data && data.length > 0) {
+        setSelectedTask(data[0]);
+      } else {
+        setSelectedTask(null);
+      }
+    } catch (err) {
+      console.error('Error loading recount tasks:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load recount tasks.');
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    loadTasks();
+  }, [loadTasks]);
+
+  async function handleTaskCompleted(task: RecountTask) {
+    try {
+      setSubmittingTaskId(task.id);
+      const { error: updateError } = await supabase
+        .from('recount_tasks')
+        .update({ status: 'done', completed_at: new Date().toISOString() })
+        .eq('id', task.id);
+
+      if (updateError) throw updateError;
+      await loadTasks();
+    } catch (err) {
+      console.error('Error marking task as done:', err);
+      setError(err instanceof Error ? err.message : 'Failed to update task status.');
+    } finally {
+      setSubmittingTaskId(null);
+    }
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="mb-6 flex flex-col gap-2">
+        <h2 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <ClipboardList className="h-6 w-6 text-blue-600" />
+          Recounts
+        </h2>
+        <p className="text-gray-600 text-sm">
+          Review variance recounts assigned to you and submit updated counts.
+        </p>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="bg-white rounded-xl shadow-lg p-8 text-center">
+          <Loader2 className="mx-auto h-10 w-10 animate-spin text-blue-600" />
+          <p className="mt-3 text-gray-600">Loading recount tasks...</p>
+        </div>
+      ) : tasks.length === 0 ? (
+        <div className="bg-white rounded-xl shadow-lg p-8 text-center space-y-3">
+          <Search className="mx-auto h-10 w-10 text-gray-400" />
+          <h3 className="text-lg font-semibold text-gray-800">No recounts assigned</h3>
+          <p className="text-gray-600 text-sm">
+            When managers flag variances for review, you&apos;ll see them appear here.
+          </p>
+          <button
+            type="button"
+            onClick={loadTasks}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-50"
+          >
+            <RefreshCcw className="h-4 w-4" />
+            Refresh
+          </button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-[320px,1fr] gap-6">
+          <div className="bg-white rounded-xl shadow-lg p-4 space-y-4 h-fit">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-gray-800">Open Tasks</h3>
+              <button
+                type="button"
+                onClick={loadTasks}
+                className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+              >
+                <RefreshCcw className="h-4 w-4" />
+                Refresh
+              </button>
+            </div>
+
+            <div className="space-y-3">
+              {tasks.map((task) => (
+                <button
+                  key={task.id}
+                  type="button"
+                  onClick={() => setSelectedTask(task)}
+                  className={`w-full text-left rounded-lg border px-4 py-3 transition ${
+                    selectedTask?.id === task.id
+                      ? 'border-blue-500 bg-blue-50'
+                      : 'border-gray-200 hover:border-blue-200 hover:bg-blue-50/40'
+                  }`}
+                >
+                  <div className="flex items-center justify-between text-sm text-gray-500">
+                    <span>{task.warehouse || 'Warehouse'}</span>
+                    <span>{task.location || 'Location'}</span>
+                  </div>
+                  <div className="mt-2 font-semibold text-gray-900">{task.stock_code}</div>
+                  <div className="text-sm text-gray-600">Lot {task.lot_number}</div>
+                  {task.description && (
+                    <p className="mt-2 text-sm text-gray-500 line-clamp-2">{task.description}</p>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-lg p-6">
+            {selectedTask ? (
+              <div className="space-y-6">
+                <div className="border-b border-gray-200 pb-4">
+                  <h3 className="text-xl font-semibold text-gray-900">Submit recount</h3>
+                  <p className="text-sm text-gray-600">
+                    Provide your updated count for <span className="font-medium">{selectedTask.stock_code}</span>{' '}
+                    (Lot {selectedTask.lot_number}). Ensure the supporting photo clearly shows the quantity counted.
+                  </p>
+                </div>
+
+                <StocktakeEntry
+                  initialStockCode={selectedTask.stock_code}
+                  initialLotNumber={selectedTask.lot_number}
+                  recountTaskId={selectedTask.id}
+                  onSubmitSuccess={() => handleTaskCompleted(selectedTask)}
+                  compact
+                  hideHeading
+                />
+
+                {submittingTaskId === selectedTask.id && (
+                  <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700 flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Updating task status...
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-gray-500">
+                <ClipboardList className="h-10 w-10" />
+                <p>Select a task from the list to begin the recount.</p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/StocktakeEntry.tsx
+++ b/src/components/StocktakeEntry.tsx
@@ -1,215 +1,341 @@
-import { useState, useRef } from 'react';
-import { Camera, Upload, Loader2, CheckCircle, X } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Camera, CheckCircle2, ImageOff, Loader2, RotateCcw, Upload } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { supabase } from '../lib/supabase';
-import { addToQueue } from '../lib/syncQueue';
 
-interface ExtractedData {
-  product_name: string;
-  barcode: string;
-  lot_number: string;
-  pack_size: string;
-  mock?: boolean;
-  message?: string;
+type CountMode = 'singles' | 'pick_face' | 'bulk';
+type UnitOption = 'units' | 'cases' | 'layers' | 'pallets';
+
+interface StocktakeEntryProps {
+  initialStockCode?: string;
+  initialLotNumber?: string;
+  recountTaskId?: string;
+  onSubmitSuccess?: () => Promise<void> | void;
+  compact?: boolean;
+  hideHeading?: boolean;
 }
 
-export default function StocktakeEntry() {
+const COUNT_MODE_OPTIONS: Record<CountMode, { label: string; units: UnitOption[] }> = {
+  singles: {
+    label: 'Singles',
+    units: ['units', 'cases']
+  },
+  pick_face: {
+    label: 'Pick Face',
+    units: ['layers', 'cases']
+  },
+  bulk: {
+    label: 'Bulk',
+    units: ['pallets', 'layers', 'cases']
+  }
+};
+
+export default function StocktakeEntry({
+  initialStockCode,
+  initialLotNumber,
+  recountTaskId,
+  onSubmitSuccess,
+  compact = false,
+  hideHeading = false
+}: StocktakeEntryProps) {
   const { user } = useAuth();
-  const [imagePreview, setImagePreview] = useState<string | null>(null);
-  const [imageFile, setImageFile] = useState<File | null>(null);
-  const [extracting, setExtracting] = useState(false);
-  const [uploading, setUploading] = useState(false);
-  const [extractedData, setExtractedData] = useState<ExtractedData | null>(null);
+  const [countMode, setCountMode] = useState<CountMode>('singles');
+  const [unit, setUnit] = useState<UnitOption>('units');
   const [quantity, setQuantity] = useState('');
-  const [unitType, setUnitType] = useState<'pallet' | 'case' | 'layer'>('case');
-  const [branch, setBranch] = useState('');
-  const [location, setLocation] = useState('');
-  const [expiryDate, setExpiryDate] = useState('');
-  const [success, setSuccess] = useState(false);
-  const [error, setError] = useState('');
+  const [stockCode, setStockCode] = useState(initialStockCode ?? '');
+  const [lotNumber, setLotNumber] = useState(initialLotNumber ?? '');
+  const [notes, setNotes] = useState('');
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
 
-  function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (file) {
-      setImageFile(file);
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        const result = reader.result as string;
-        setImagePreview(result);
-        handleExtract(result);
-      };
-      reader.readAsDataURL(file);
-      setExtractedData(null);
-      setSuccess(false);
-      setError('');
+  useEffect(() => {
+    setStockCode(initialStockCode ?? '');
+  }, [initialStockCode]);
+
+  useEffect(() => {
+    setLotNumber(initialLotNumber ?? '');
+  }, [initialLotNumber]);
+
+  useEffect(() => {
+    const availableUnits = COUNT_MODE_OPTIONS[countMode].units;
+    if (!availableUnits.includes(unit)) {
+      setUnit(availableUnits[0]);
     }
+  }, [countMode, unit]);
+
+  const availableUnits = useMemo(() => COUNT_MODE_OPTIONS[countMode].units, [countMode]);
+
+  function handleFileSelect(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setPhotoFile(file);
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = reader.result as string;
+      setPhotoPreview(result);
+    };
+    reader.readAsDataURL(file);
+    setErrorMessage('');
+    setSuccessMessage('');
   }
 
-  async function handleExtract(imageData?: string) {
-    const dataToUse = imageData || imagePreview;
-    if (!dataToUse) return;
-
-    setExtracting(true);
-    setError('');
-
-    try {
-      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/extract-product-info`;
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ image_base64: dataToUse })
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to extract product information');
-      }
-
-      const data: ExtractedData = await response.json();
-      setExtractedData(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to extract data');
-    } finally {
-      setExtracting(false);
+  function resetPhoto() {
+    setPhotoFile(null);
+    setPhotoPreview(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
     }
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!imageFile || !user || !extractedData) return;
-
-    setUploading(true);
-    setError('');
-
-    const quantityNumber = parseInt(quantity, 10);
-
-    try {
-      const fileExt = imageFile.name.split('.').pop();
-      const fileName = `${user.id}/${Date.now()}.${fileExt}`;
-
-      const { error: uploadError } = await supabase.storage
-        .from('stocktake-images')
-        .upload(fileName, imageFile);
-
-      if (uploadError) throw uploadError;
-
-      const { data: { publicUrl } } = supabase.storage
-        .from('stocktake-images')
-        .getPublicUrl(fileName);
-
-      let productId = null;
-      if (extractedData.barcode) {
-        const { data: product } = await supabase
-          .from('products')
-          .select('id')
-          .eq('barcode', extractedData.barcode)
-          .maybeSingle();
-
-        productId = product?.id || null;
-      }
-
-      const { error: insertError } = await supabase
-        .from('stocktake_entries')
-        .insert({
-          user_id: user.id,
-          product_id: productId,
-          image_url: publicUrl,
-          extracted_product_name: extractedData.product_name,
-          extracted_barcode: extractedData.barcode,
-          extracted_lot_number: extractedData.lot_number,
-          extracted_pack_size: extractedData.pack_size,
-          actual_quantity: quantityNumber,
-          unit_type: unitType,
-          branch: branch,
-          location: location,
-          expiry_date: expiryDate || null,
-          synced: true
-        });
-
-      if (insertError) throw insertError;
-
-      setSuccess(true);
-      setTimeout(() => {
-        resetForm();
-      }, 2000);
-    } catch (err) {
-      if (!navigator.onLine && imagePreview && extractedData) {
-        addToQueue({
-          imageFile,
-          imageDataUrl: imagePreview,
-          extractedData,
-          quantity: quantityNumber,
-          unitType,
-          branch,
-          location,
-          expiryDate: expiryDate || null
-        });
-
-        setSuccess(true);
-        setTimeout(() => {
-          resetForm();
-        }, 2000);
-      } else {
-        setError(err instanceof Error ? err.message : 'Failed to save entry');
-      }
-    } finally {
-      setUploading(false);
+    if (cameraInputRef.current) {
+      cameraInputRef.current.value = '';
     }
   }
 
   function resetForm() {
-    setImagePreview(null);
-    setImageFile(null);
-    setExtractedData(null);
+    setCountMode('singles');
+    setUnit('units');
     setQuantity('');
-    setUnitType('case');
-    setBranch('');
-    setLocation('');
-    setExpiryDate('');
-    setSuccess(false);
-    setError('');
+    setNotes('');
+    resetPhoto();
+    setErrorMessage('');
+    if (!initialStockCode) {
+      setStockCode('');
+    }
+    if (!initialLotNumber) {
+      setLotNumber('');
+    }
   }
 
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!user) return;
+    if (!photoFile) {
+      setErrorMessage('A photo is required before submitting.');
+      return;
+    }
+
+    setSubmitting(true);
+    setErrorMessage('');
+
+    try {
+      const {
+        data: { session }
+      } = await supabase.auth.getSession();
+
+      if (!session?.access_token) {
+        throw new Error('Unable to authenticate request. Please sign in again.');
+      }
+
+      const formData = new FormData();
+      formData.append('count_mode', countMode);
+      formData.append('unit', unit);
+      formData.append('quantity', quantity);
+      formData.append('stock_code', stockCode);
+      formData.append('lot_number', lotNumber);
+      formData.append('notes', notes);
+      formData.append('submitted_by', user.id);
+      if (recountTaskId) {
+        formData.append('recount_task_id', recountTaskId);
+      }
+      formData.append('photo', photoFile);
+
+      const response = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/submit-count`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${session.access_token}`
+          },
+          body: formData
+        }
+      );
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Failed to submit count.');
+      }
+
+      setSuccessMessage('Captured ✓ — processing in background');
+      resetForm();
+      if (onSubmitSuccess) {
+        await onSubmitSuccess();
+      }
+    } catch (error) {
+      console.error('Error submitting count:', error);
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to submit count.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const wrapperClass = compact ? '' : 'max-w-3xl mx-auto';
+  const cardClass = compact ? 'space-y-6' : 'bg-white rounded-xl shadow-lg p-6 space-y-6';
+
   return (
-    <div className="max-w-4xl mx-auto">
-      <div className="bg-white rounded-xl shadow-lg p-6">
-        <h2 className="text-2xl font-bold text-gray-800 mb-6">New Stocktake Entry</h2>
+    <div className={wrapperClass}>
+      <div className={cardClass}>
+        {!hideHeading && (
+          <div className="flex flex-col gap-4">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Capture Count</h2>
+              <p className="text-gray-600 text-sm">Upload a count with supporting photo evidence.</p>
+            </div>
 
-        {success && (
-          <div className="mb-6 bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg flex items-center">
-            <CheckCircle className="w-5 h-5 mr-2" />
-            Entry saved successfully!
+            <div className="flex flex-wrap gap-3">
+              {(Object.keys(COUNT_MODE_OPTIONS) as CountMode[]).map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => setCountMode(mode)}
+                  className={`px-4 py-2 rounded-lg border transition-colors ${
+                    countMode === mode
+                      ? 'border-blue-600 bg-blue-50 text-blue-700 font-semibold'
+                      : 'border-gray-200 bg-white text-gray-700 hover:border-blue-200'
+                  }`}
+                >
+                  {COUNT_MODE_OPTIONS[mode].label}
+                </button>
+              ))}
+            </div>
           </div>
         )}
 
-        {error && (
-          <div className="mb-6 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
-            {error}
+        {hideHeading && (
+          <div className="flex flex-wrap gap-3">
+            {(Object.keys(COUNT_MODE_OPTIONS) as CountMode[]).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setCountMode(mode)}
+                className={`px-4 py-2 rounded-lg border transition-colors ${
+                  countMode === mode
+                    ? 'border-blue-600 bg-blue-50 text-blue-700 font-semibold'
+                    : 'border-gray-200 bg-white text-gray-700 hover:border-blue-200'
+                }`}
+              >
+                {COUNT_MODE_OPTIONS[mode].label}
+              </button>
+            ))}
           </div>
         )}
 
-        {!imagePreview ? (
+        {successMessage && (
+          <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700 flex items-center gap-2">
+            <CheckCircle2 className="h-5 w-5" />
+            {successMessage}
+          </div>
+        )}
+
+        {errorMessage && (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {errorMessage}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+              Stock Code
+              <input
+                type="text"
+                value={stockCode}
+                onChange={(event) => setStockCode(event.target.value.toUpperCase())}
+                required
+                placeholder="e.g. SKU-12345"
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+
+            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+              Lot Number
+              <input
+                type="text"
+                value={lotNumber}
+                onChange={(event) => setLotNumber(event.target.value)}
+                required
+                placeholder="Batch or lot reference"
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+              Quantity
+              <input
+                type="number"
+                min="0"
+                step="1"
+                value={quantity}
+                onChange={(event) => setQuantity(event.target.value)}
+                required
+                placeholder="Enter amount counted"
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+
+            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+              Unit
+              <select
+                value={unit}
+                onChange={(event) => setUnit(event.target.value as UnitOption)}
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              >
+                {availableUnits.map((option) => (
+                  <option key={option} value={option}>
+                    {option.charAt(0).toUpperCase() + option.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700 md:col-span-1 md:col-start-auto">
+              Notes
+              <input
+                type="text"
+                value={notes}
+                onChange={(event) => setNotes(event.target.value)}
+                placeholder="Optional comments"
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+          </div>
+
           <div className="space-y-4">
-            <button
-              onClick={() => cameraInputRef.current?.click()}
-              className="w-full bg-blue-600 text-white py-4 rounded-lg font-medium hover:bg-blue-700 transition-all flex items-center justify-center gap-2"
-            >
-              <Camera className="w-5 h-5" />
-              Take Photo
-            </button>
-
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              className="w-full bg-gray-600 text-white py-4 rounded-lg font-medium hover:bg-gray-700 transition-all flex items-center justify-center gap-2"
-            >
-              <Upload className="w-5 h-5" />
-              Upload Photo
-            </button>
+            <div className="flex gap-3 flex-wrap">
+              <button
+                type="button"
+                onClick={() => cameraInputRef.current?.click()}
+                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white shadow-sm transition hover:bg-blue-700"
+              >
+                <Camera className="h-5 w-5" />
+                Take Photo
+              </button>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="inline-flex items-center gap-2 rounded-lg bg-gray-600 px-4 py-2 text-white shadow-sm transition hover:bg-gray-700"
+              >
+                <Upload className="h-5 w-5" />
+                Upload Photo
+              </button>
+              {photoPreview && (
+                <button
+                  type="button"
+                  onClick={resetPhoto}
+                  className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-100"
+                >
+                  <RotateCcw className="h-5 w-5" />
+                  Retake
+                </button>
+              )}
+            </div>
 
             <input
               ref={cameraInputRef}
@@ -226,179 +352,34 @@ export default function StocktakeEntry() {
               onChange={handleFileSelect}
               className="hidden"
             />
-          </div>
-        ) : (
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="relative">
-              <img
-                src={imagePreview}
-                alt="Product preview"
-                className="w-full h-64 object-contain bg-gray-100 rounded-lg"
-              />
-              <button
-                type="button"
-                onClick={resetForm}
-                className="absolute top-2 right-2 bg-red-600 text-white p-2 rounded-full hover:bg-red-700 transition-all"
-              >
-                <X className="w-5 h-5" />
-              </button>
+
+            <div className="overflow-hidden rounded-lg border border-dashed border-gray-300 bg-gray-50">
+              {photoPreview ? (
+                <img src={photoPreview} alt="Count evidence" className="h-64 w-full object-contain bg-white" />
+              ) : (
+                <div className="flex h-64 flex-col items-center justify-center gap-2 text-gray-500">
+                  <ImageOff className="h-10 w-10" />
+                  <p className="text-sm">No photo selected yet</p>
+                </div>
+              )}
             </div>
+          </div>
 
-            {extracting && (
-              <div className="bg-blue-50 border border-blue-200 text-blue-700 px-4 py-3 rounded-lg flex items-center justify-center gap-2">
-                <Loader2 className="w-5 h-5 animate-spin" />
-                Extracting product information...
-              </div>
-            )}
-
-            {extractedData && (
+          <button
+            type="submit"
+            disabled={submitting || !stockCode || !lotNumber || !quantity || !photoFile}
+            className="w-full inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-3 text-white font-semibold shadow-sm transition enabled:hover:bg-blue-700 disabled:opacity-60"
+          >
+            {submitting ? (
               <>
-                {extractedData.mock && (
-                  <div className="bg-yellow-50 border border-yellow-200 text-yellow-800 px-4 py-3 rounded-lg text-sm">
-                    {extractedData.message}
-                  </div>
-                )}
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Product Name
-                    </label>
-                    <input
-                      type="text"
-                      value={extractedData.product_name}
-                      onChange={(e) => setExtractedData({ ...extractedData, product_name: e.target.value })}
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Barcode
-                    </label>
-                    <input
-                      type="text"
-                      value={extractedData.barcode}
-                      onChange={(e) => setExtractedData({ ...extractedData, barcode: e.target.value })}
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Lot Number
-                    </label>
-                    <input
-                      type="text"
-                      value={extractedData.lot_number}
-                      onChange={(e) => setExtractedData({ ...extractedData, lot_number: e.target.value })}
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Pack Size
-                    </label>
-                    <input
-                      type="text"
-                      value={extractedData.pack_size}
-                      onChange={(e) => setExtractedData({ ...extractedData, pack_size: e.target.value })}
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    />
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Branch *
-                    </label>
-                    <input
-                      type="text"
-                      value={branch}
-                      onChange={(e) => setBranch(e.target.value)}
-                      required
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                      placeholder="e.g., Main Warehouse"
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Location *
-                    </label>
-                    <input
-                      type="text"
-                      value={location}
-                      onChange={(e) => setLocation(e.target.value)}
-                      required
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                      placeholder="e.g., A-01"
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Expiry Date
-                    </label>
-                    <input
-                      type="date"
-                      value={expiryDate}
-                      onChange={(e) => setExpiryDate(e.target.value)}
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Quantity *
-                    </label>
-                    <input
-                      type="number"
-                      value={quantity}
-                      onChange={(e) => setQuantity(e.target.value)}
-                      required
-                      min="0"
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                      placeholder="Enter quantity"
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Unit Type *
-                    </label>
-                    <select
-                      value={unitType}
-                      onChange={(e) => setUnitType(e.target.value as 'pallet' | 'case' | 'layer')}
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    >
-                      <option value="pallet">Pallet</option>
-                      <option value="case">Case</option>
-                      <option value="layer">Layer</option>
-                    </select>
-                  </div>
-                </div>
-
-                <button
-                  type="submit"
-                  disabled={uploading || !quantity || !branch || !location}
-                  className="w-full bg-blue-600 text-white py-3 rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 transition-all flex items-center justify-center gap-2"
-                >
-                  {uploading ? (
-                    <>
-                      <Loader2 className="w-5 h-5 animate-spin" />
-                      Saving...
-                    </>
-                  ) : (
-                    'Save Entry'
-                  )}
-                </button>
+                <Loader2 className="h-5 w-5 animate-spin" />
+                Capturing...
               </>
+            ) : (
+              'Submit Count'
             )}
-          </form>
-        )}
+          </button>
+        </form>
       </div>
     </div>
   );

--- a/src/components/VarianceReports.tsx
+++ b/src/components/VarianceReports.tsx
@@ -1,295 +1,280 @@
-import { useState, useEffect, useCallback } from 'react';
-import { AlertTriangle, TrendingUp, TrendingDown, CheckCircle, FileText } from 'lucide-react';
-import { supabase, VarianceReport, Product } from '../lib/supabase';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle, Download, Loader2 } from 'lucide-react';
+import { supabase } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
 
-type VarianceReportWithProduct = VarianceReport & { product: Product | null };
+type VarianceRow = {
+  id: string;
+  description: string;
+  lot: string;
+  variance: number;
+  warehouse_id: string;
+  warehouse_name?: string | null;
+  event_name?: string | null;
+  product_code?: string | null;
+  created_at?: string;
+};
+
+type WarehouseAssignment = {
+  warehouse_id: string;
+  warehouse?: { id: string; name: string } | null;
+};
 
 export default function VarianceReports() {
   const { profile } = useAuth();
-  const [reports, setReports] = useState<VarianceReportWithProduct[]>([]);
+  const [rows, setRows] = useState<VarianceRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [filter, setFilter] = useState<'all' | 'pending' | 'reviewed' | 'resolved'>('all');
-  const [selectedReport, setSelectedReport] = useState<VarianceReportWithProduct | null>(null);
-  const [reviewNotes, setReviewNotes] = useState('');
-  const [updating, setUpdating] = useState(false);
+  const [error, setError] = useState('');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [assigning, setAssigning] = useState(false);
+  const [warehouses, setWarehouses] = useState<WarehouseAssignment[]>([]);
+  const [assignedWarehouseIds, setAssignedWarehouseIds] = useState<string[]>([]);
 
-  const loadReports = useCallback(async () => {
+  const warehouseOptions = useMemo(() => {
+    return warehouses
+      .map((assignment) => assignment.warehouse)
+      .filter((w): w is { id: string; name: string } => Boolean(w));
+  }, [warehouses]);
+
+  const canAssign = selected.size > 0 && !assigning;
+
+  const loadWarehouses = useCallback(async () => {
+    if (!profile) {
+      setWarehouses([]);
+      setAssignedWarehouseIds([]);
+      return [];
+    }
+
     try {
-      setLoading(true);
-      let query = supabase
-        .from('variance_reports')
-        .select(`
-          *,
-          product:products(*)
-        `)
-        .order('created_at', { ascending: false });
+      const { data, error: queryError } = await supabase
+        .from('user_warehouse_assignments')
+        .select('warehouse_id, warehouses(id, name)')
+        .eq('user_id', profile.id);
 
-      if (filter !== 'all') {
-        query = query.eq('status', filter);
+      if (queryError) throw queryError;
+
+      const normalized: WarehouseAssignment[] = (data ?? []).map((assignment: any) => ({
+        warehouse_id: assignment.warehouse_id as string,
+        warehouse: Array.isArray(assignment.warehouses)
+          ? assignment.warehouses[0] ?? null
+          : assignment.warehouses ?? null
+      }));
+
+      setWarehouses(normalized);
+      const ids = normalized
+        .map((assignment) => assignment.warehouse_id)
+        .filter((id): id is string => Boolean(id));
+      setAssignedWarehouseIds(ids);
+      return ids;
+    } catch (err) {
+      console.error('Error loading warehouse assignments:', err);
+      setError(err instanceof Error ? err.message : 'Unable to load warehouse assignments.');
+      return [];
+    }
+  }, [profile]);
+
+  const loadVariance = useCallback(
+    async (ids: string[]) => {
+      if (ids.length === 0) {
+        setRows([]);
+        setLoading(false);
+        return;
       }
 
-      const { data, error } = await query;
+      try {
+        setLoading(true);
+        setError('');
+        const { data, error: queryError } = await supabase
+          .from('manager_variance_view')
+          .select('*')
+          .in('warehouse_id', ids)
+          .order('created_at', { ascending: false });
 
-      if (error) throw error;
-      setReports(data as VarianceReportWithProduct[]);
-    } catch (error) {
-      console.error('Error loading reports:', error);
-    } finally {
-      setLoading(false);
-    }
-  }, [filter]);
+        if (queryError) throw queryError;
+        const typedRows = (data ?? []) as VarianceRow[];
+        setRows(typedRows);
+      } catch (err) {
+        console.error('Error loading variance view:', err);
+        setError(err instanceof Error ? err.message : 'Failed to load variance data.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
 
   useEffect(() => {
-    loadReports();
-  }, [loadReports]);
-
-  async function updateReportStatus(reportId: string, status: 'reviewed' | 'resolved', notes: string) {
-    if (!profile) return;
-
-    setUpdating(true);
-    try {
-      const { error } = await supabase
-        .from('variance_reports')
-        .update({
-          status,
-          reviewed_by: profile.id,
-          notes,
-          updated_at: new Date().toISOString()
-        })
-        .eq('id', reportId);
-
-      if (error) throw error;
-
-      await loadReports();
-      setSelectedReport(null);
-      setReviewNotes('');
-    } catch (error) {
-      console.error('Error updating report:', error);
-    } finally {
-      setUpdating(false);
+    async function initialise() {
+      const ids = await loadWarehouses();
+      if (ids.length > 0) {
+        await loadVariance(ids);
+      } else {
+        setLoading(false);
+        setRows([]);
+      }
     }
+
+    initialise();
+  }, [loadVariance, loadWarehouses]);
+
+  function toggleSelection(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
   }
 
-  function getVarianceColor(percentage: number) {
-    const abs = Math.abs(percentage);
-    if (abs < 5) return 'text-green-600';
-    if (abs < 15) return 'text-yellow-600';
-    return 'text-red-600';
-  }
+  async function handleAssignRecounts() {
+    if (selected.size === 0) return;
+    setAssigning(true);
+    setError('');
 
-  function getVarianceBgColor(percentage: number) {
-    const abs = Math.abs(percentage);
-    if (abs < 5) return 'bg-green-50 border-green-200';
-    if (abs < 15) return 'bg-yellow-50 border-yellow-200';
-    return 'bg-red-50 border-red-200';
+    try {
+      const {
+        data: { session }
+      } = await supabase.auth.getSession();
+
+      if (!session?.access_token) {
+        throw new Error('Unable to authenticate assign request.');
+      }
+
+      const response = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/assign-recounts`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session.access_token}`
+          },
+          body: JSON.stringify({ variance_ids: Array.from(selected) })
+        }
+      );
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Failed to assign recounts.');
+      }
+
+      setSelected(new Set());
+      if (assignedWarehouseIds.length > 0) {
+        await loadVariance(assignedWarehouseIds);
+      }
+    } catch (err) {
+      console.error('Error assigning recounts:', err);
+      setError(err instanceof Error ? err.message : 'Failed to assign recounts.');
+    } finally {
+      setAssigning(false);
+    }
   }
 
   if (loading) {
     return (
       <div className="max-w-6xl mx-auto">
         <div className="bg-white rounded-xl shadow-lg p-8 text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600">Loading reports...</p>
+          <Loader2 className="mx-auto h-10 w-10 animate-spin text-blue-600" />
+          <p className="mt-3 text-gray-600">Loading variance data…</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="max-w-6xl mx-auto">
+    <div className="max-w-6xl mx-auto space-y-6">
       <div className="bg-white rounded-xl shadow-lg p-6">
-        <div className="flex items-center justify-between mb-6">
-          <h2 className="text-2xl font-bold text-gray-800 flex items-center gap-2">
-            <FileText className="w-7 h-7" />
-            Variance Reports
-          </h2>
-          <div className="flex gap-2">
-            <button
-              onClick={() => setFilter('all')}
-              className={`px-4 py-2 rounded-lg font-medium transition-all ${
-                filter === 'all'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              All
-            </button>
-            <button
-              onClick={() => setFilter('pending')}
-              className={`px-4 py-2 rounded-lg font-medium transition-all ${
-                filter === 'pending'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              Pending
-            </button>
-            <button
-              onClick={() => setFilter('reviewed')}
-              className={`px-4 py-2 rounded-lg font-medium transition-all ${
-                filter === 'reviewed'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              Reviewed
-            </button>
-            <button
-              onClick={() => setFilter('resolved')}
-              className={`px-4 py-2 rounded-lg font-medium transition-all ${
-                filter === 'resolved'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              Resolved
-            </button>
-          </div>
-        </div>
-
-        {reports.length === 0 ? (
-          <div className="text-center py-12">
-            <CheckCircle className="w-16 h-16 text-green-600 mx-auto mb-4" />
-            <h3 className="text-xl font-semibold text-gray-800 mb-2">No Reports Found</h3>
-            <p className="text-gray-600">
-              {filter === 'all'
-                ? 'No variance reports have been generated yet'
-                : `No ${filter} reports at this time`}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900">Variance Overview</h2>
+            <p className="text-gray-600 text-sm">
+              Review stock variances across your assigned warehouses. Select rows to trigger recount tasks.
             </p>
           </div>
+          <button
+            type="button"
+            onClick={handleAssignRecounts}
+            disabled={!canAssign}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+          >
+            {assigning ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+            Assign Recounts
+          </button>
+        </div>
+
+        {error && (
+          <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+        )}
+
+        {rows.length === 0 ? (
+          <div className="mt-6 flex flex-col items-center justify-center gap-3 py-10 text-gray-600">
+            <CheckCircle className="h-10 w-10 text-green-500" />
+            <p className="text-base font-medium">No variances detected for your warehouses.</p>
+          </div>
         ) : (
-          <div className="space-y-4">
-            {reports.map((report) => (
-              <div
-                key={report.id}
-                className={`border rounded-lg p-4 transition-all ${getVarianceBgColor(report.variance_percentage)}`}
-              >
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
-                    <h3 className="font-semibold text-gray-800 text-lg mb-2">
-                      {report.product?.product_name || 'Unknown Product'}
-                    </h3>
-                    <div className="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm">
-                      <div>
-                        <span className="text-gray-600">Barcode:</span>
-                        <p className="font-medium font-mono">{report.product?.barcode || 'N/A'}</p>
-                      </div>
-                      <div>
-                        <span className="text-gray-600">Lot:</span>
-                        <p className="font-medium">{report.lot_number || 'N/A'}</p>
-                      </div>
-                      <div>
-                        <span className="text-gray-600">Expected (units):</span>
-                        <p className="font-medium">{report.expected_units ?? report.expected_quantity}</p>
-                      </div>
-                      <div>
-                        <span className="text-gray-600">Actual (units):</span>
-                        <p className="font-medium">{report.actual_units ?? report.actual_quantity}</p>
-                      </div>
-                      <div>
-                        <span className="text-gray-600">Variance:</span>
-                        <p className={`font-bold ${getVarianceColor(report.variance_percentage)} flex items-center gap-1`}>
-                          {report.variance > 0 ? (
-                            <TrendingUp className="w-4 h-4" />
-                          ) : (
-                            <TrendingDown className="w-4 h-4" />
-                          )}
-                          {report.variance} ({report.variance_percentage.toFixed(1)}%)
-                        </p>
-                      </div>
-                    </div>
-                    <div className="mt-3 flex items-center gap-4">
-                      <span className={`px-3 py-1 rounded-full text-xs font-medium ${
-                        report.status === 'pending' ? 'bg-yellow-100 text-yellow-800' :
-                        report.status === 'reviewed' ? 'bg-blue-100 text-blue-800' :
-                        'bg-green-100 text-green-800'
-                      }`}>
-                        {report.status.toUpperCase()}
-                      </span>
-                      <span className="text-xs text-gray-500">
-                        {new Date(report.created_at).toLocaleString()}
-                      </span>
-                    </div>
-                    {report.notes && (
-                      <div className="mt-2 text-sm text-gray-700 bg-white bg-opacity-60 p-2 rounded">
-                        <strong>Notes:</strong> {report.notes}
-                      </div>
-                    )}
-                  </div>
-                  {profile?.role && ['manager', 'admin'].includes(profile.role) && report.status !== 'resolved' && (
-                    <button
-                      onClick={() => {
-                        setSelectedReport(report);
-                        setReviewNotes(report.notes || '');
-                      }}
-                      className="ml-4 bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-all flex items-center gap-2"
-                    >
-                      <AlertTriangle className="w-4 h-4" />
-                      Review
-                    </button>
-                  )}
-                </div>
-              </div>
-            ))}
+          <div className="mt-6 overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    <span className="sr-only">Select</span>
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Description
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">Lot</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Variance
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Warehouse
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Event
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 bg-white">
+                {rows.map((row) => {
+                  const isSelected = selected.has(row.id);
+                  const varianceClass = row.variance === 0 ? 'text-gray-600' : row.variance > 0 ? 'text-green-600' : 'text-red-600';
+                  return (
+                    <tr key={row.id} className={isSelected ? 'bg-blue-50' : undefined}>
+                      <td className="px-4 py-3">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleSelection(row.id)}
+                          className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        />
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-900">
+                        <div className="font-semibold">{row.description}</div>
+                        {row.product_code && (
+                          <div className="text-xs text-gray-500">Code: {row.product_code}</div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-700">{row.lot || '—'}</td>
+                      <td className={`px-4 py-3 text-sm font-semibold ${varianceClass}`}>
+                        <div className="flex items-center gap-2">
+                          {row.variance === 0 ? <CheckCircle className="h-4 w-4" /> : <AlertTriangle className="h-4 w-4" />}
+                          {row.variance}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-700">
+                        {row.warehouse_name || warehouseOptions.find((w) => w.id === row.warehouse_id)?.name || '—'}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-700">{row.event_name || '—'}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
         )}
       </div>
-
-      {selectedReport && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-xl shadow-2xl p-6 max-w-md w-full">
-            <h3 className="text-xl font-bold text-gray-800 mb-4">Review Variance Report</h3>
-
-            <div className="mb-4 p-4 bg-gray-50 rounded-lg">
-              <p className="font-semibold">{selectedReport.product?.product_name}</p>
-              <p className="text-sm text-gray-600 mt-1">
-                Variance: {selectedReport.variance} ({selectedReport.variance_percentage.toFixed(1)}%)
-              </p>
-            </div>
-
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                Review Notes
-              </label>
-              <textarea
-                value={reviewNotes}
-                onChange={(e) => setReviewNotes(e.target.value)}
-                rows={4}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                placeholder="Add your notes here..."
-              />
-            </div>
-
-            <div className="flex gap-2">
-              <button
-                onClick={() => updateReportStatus(selectedReport.id, 'reviewed', reviewNotes)}
-                disabled={updating}
-                className="flex-1 bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 transition-all"
-              >
-                {updating ? 'Updating...' : 'Mark Reviewed'}
-              </button>
-              <button
-                onClick={() => updateReportStatus(selectedReport.id, 'resolved', reviewNotes)}
-                disabled={updating}
-                className="flex-1 bg-green-600 text-white py-2 rounded-lg font-medium hover:bg-green-700 disabled:opacity-50 transition-all"
-              >
-                {updating ? 'Updating...' : 'Mark Resolved'}
-              </button>
-              <button
-                onClick={() => {
-                  setSelectedReport(null);
-                  setReviewNotes('');
-                }}
-                disabled={updating}
-                className="px-4 bg-gray-200 text-gray-700 rounded-lg font-medium hover:bg-gray-300 disabled:opacity-50 transition-all"
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- redesign the stock taker count form with tabbed units, required photo capture, and submission via the `submit-count` function
- add a recounts workflow, integrate new export tooling, and expose the pages through the dashboard navigation
- replace the manager variance view with a read-only table backed by `manager_variance_view` and an "Assign Recounts" action

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e43b7842c88329849e756a76053a75