### PR TITLE
feat: refresh stocktake count workflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
+import { EventWarehouseProvider } from './contexts/EventWarehouseContext';
 import Login from './components/Login';
 import Register from './components/Register';
 import Dashboard from './components/Dashboard';
@@ -33,7 +34,9 @@ function AppContent() {
 function App() {
   return (
     <AuthProvider>
-      <AppContent />
+      <EventWarehouseProvider>
+        <AppContent />
+      </EventWarehouseProvider>
     </AuthProvider>
   );
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -13,6 +13,7 @@ import {
   X
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { useEventWarehouse } from '../contexts/EventWarehouseContext';
 import StocktakeEntry from './StocktakeEntry';
 import VarianceReports from './VarianceReports';
 import UserManagement from './UserManagement';
@@ -28,6 +29,14 @@ export default function Dashboard() {
   const { profile, signOut } = useAuth();
   const [currentPage, setCurrentPage] = useState<Page>('stocktake');
   const [menuOpen, setMenuOpen] = useState(false);
+  const {
+    events,
+    eventId,
+    setEventId,
+    warehouses,
+    warehouseCode,
+    setWarehouseCode
+  } = useEventWarehouse();
 
   async function handleSignOut() {
     try {
@@ -139,6 +148,36 @@ export default function Dashboard() {
                 <Camera className="w-8 h-8 text-blue-600" />
                 <h1 className="ml-2 text-xl font-bold text-gray-800">Smart Stocktake</h1>
               </div>
+              <div className="hidden md:flex items-center gap-3 ml-6">
+                <select
+                  value={eventId ?? ''}
+                  onChange={(event) => setEventId(event.target.value)}
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                >
+                  <option value="" disabled>
+                    Select event
+                  </option>
+                  {events.map((event) => (
+                    <option key={event.id} value={event.id}>
+                      {event.name}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={warehouseCode ?? ''}
+                  onChange={(event) => setWarehouseCode(event.target.value)}
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                >
+                  <option value="" disabled>
+                    Select warehouse
+                  </option>
+                  {warehouses.map((warehouse) => (
+                    <option key={warehouse.code} value={warehouse.code}>
+                      {warehouse.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
 
             <div className="hidden md:flex items-center gap-6">
@@ -193,6 +232,42 @@ export default function Dashboard() {
         {menuOpen && (
           <div className="md:hidden border-t border-gray-200 bg-white">
             <div className="px-4 py-3 space-y-2">
+              <div className="space-y-2">
+                <label className="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Event
+                  <select
+                    value={eventId ?? ''}
+                    onChange={(event) => setEventId(event.target.value)}
+                    className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  >
+                    <option value="" disabled>
+                      Select event
+                    </option>
+                    {events.map((event) => (
+                      <option key={event.id} value={event.id}>
+                        {event.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Warehouse
+                  <select
+                    value={warehouseCode ?? ''}
+                    onChange={(event) => setWarehouseCode(event.target.value)}
+                    className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  >
+                    <option value="" disabled>
+                      Select warehouse
+                    </option>
+                    {warehouses.map((warehouse) => (
+                      <option key={warehouse.code} value={warehouse.code}>
+                        {warehouse.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
               <MobileNavButton page="stocktake" label="Stocktake" icon={<Camera className="w-5 h-5" />} />
               <MobileNavButton page="recounts" label="Recounts" icon={<ClipboardList className="w-5 h-5" />} />
               <MobileNavButton page="sync" label="Sync Queue" icon={<Upload className="w-5 h-5" />} />

--- a/src/components/ExportCounts.tsx
+++ b/src/components/ExportCounts.tsx
@@ -1,106 +1,36 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Download, Loader2 } from 'lucide-react';
-import { supabase } from '../lib/supabase';
-
-interface EventOption {
-  id: string;
-  name: string;
-}
-
-interface WarehouseOption {
-  id: string;
-  name: string;
-}
+import { useEventWarehouse } from '../contexts/EventWarehouseContext';
+import { useExportCounts } from '../hooks/useExportCounts';
 
 export default function ExportCounts() {
-  const [events, setEvents] = useState<EventOption[]>([]);
-  const [warehouses, setWarehouses] = useState<WarehouseOption[]>([]);
-  const [selectedEvent, setSelectedEvent] = useState('');
-  const [selectedWarehouse, setSelectedWarehouse] = useState('');
-  const [loading, setLoading] = useState(true);
-  const [downloading, setDownloading] = useState(false);
-  const [error, setError] = useState('');
+  const { eventId, warehouseCode, selectedEvent, selectedWarehouse } = useEventWarehouse();
+  const exportMutation = useExportCounts();
   const [notice, setNotice] = useState('');
-
-  useEffect(() => {
-    async function loadOptions() {
-      setLoading(true);
-      setError('');
-      try {
-        const [{ data: eventData, error: eventError }, { data: warehouseData, error: warehouseError }] = await Promise.all([
-          supabase.from('stocktake_events').select('id, name').order('name'),
-          supabase.from('warehouses').select('id, name').order('name')
-        ]);
-
-        if (eventError) throw eventError;
-        if (warehouseError) throw warehouseError;
-
-        setEvents(eventData ?? []);
-        setWarehouses(warehouseData ?? []);
-      } catch (err) {
-        console.error('Error loading export options:', err);
-        setError(err instanceof Error ? err.message : 'Failed to load export filters.');
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    loadOptions();
-  }, []);
+  const [error, setError] = useState('');
 
   async function handleDownload() {
-    setDownloading(true);
     setError('');
     setNotice('');
+    if (!eventId || !warehouseCode) {
+      setError('Choose an event and warehouse first.');
+      return;
+    }
 
     try {
-      const {
-        data: { session }
-      } = await supabase.auth.getSession();
-
-      if (!session?.access_token) {
-        throw new Error('Unable to authenticate download request.');
-      }
-
-      const params = new URLSearchParams();
-      if (selectedEvent) {
-        params.append('event_id', selectedEvent);
-      }
-      if (selectedWarehouse) {
-        params.append('warehouse_id', selectedWarehouse);
-      }
-
-      const response = await fetch(
-        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/export-counts?${params.toString()}`,
-        {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${session.access_token}`
-          }
-        }
-      );
-
-      if (!response.ok) {
-        const message = await response.text();
-        throw new Error(message || 'Failed to download export.');
-      }
-
-      const blob = await response.blob();
-      const downloadUrl = window.URL.createObjectURL(blob);
+      const blob = await exportMutation.mutateAsync({ eventId, warehouseCode });
+      const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');
-      link.href = downloadUrl;
-      link.download = `stock-counts-${Date.now()}.csv`;
+      link.href = url;
+      link.download = `counts-${eventId}-${warehouseCode}.csv`;
       document.body.appendChild(link);
       link.click();
-      link.remove();
-      window.URL.revokeObjectURL(downloadUrl);
-
-      setNotice('Export started. Check your downloads for the CSV file.');
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+      setNotice('Export started — check your downloads for the CSV file.');
     } catch (err) {
-      console.error('Error exporting counts:', err);
-      setError(err instanceof Error ? err.message : 'Failed to export counts.');
-    } finally {
-      setDownloading(false);
+      console.error('Export failed', err);
+      setError(err instanceof Error ? err.message : 'Failed to export counts');
     }
   }
 
@@ -108,73 +38,39 @@ export default function ExportCounts() {
     <div className="max-w-3xl mx-auto">
       <div className="bg-white rounded-xl shadow-lg p-6 space-y-6">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
-            <Download className="h-6 w-6 text-blue-600" />
-            Export Counts
+          <h2 className="flex items-center gap-2 text-2xl font-bold text-gray-900">
+            <Download className="h-6 w-6 text-blue-600" /> Export Counts
           </h2>
-          <p className="text-gray-600 text-sm mt-1">
-            Download the captured counts for auditing or reconciliation. Choose an event and warehouse to filter your export.
+          <p className="text-sm text-gray-600">
+            Download all captured counts for{' '}
+            <strong>{selectedEvent?.name ?? 'your event'}</strong> in <strong>{selectedWarehouse?.name ?? 'your warehouse'}</strong>.
           </p>
         </div>
 
-        {error && (
-          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
-        )}
-
+        {error && <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>}
         {notice && (
           <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">{notice}</div>
         )}
 
-        {loading ? (
-          <div className="flex flex-col items-center justify-center gap-3 py-12 text-gray-600">
-            <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
-            Loading export filters...
-          </div>
-        ) : (
-          <div className="space-y-4">
-            <label className="flex flex-col gap-2 text-sm font-medium text-gray-700">
-              Event
-              <select
-                value={selectedEvent}
-                onChange={(event) => setSelectedEvent(event.target.value)}
-                className="rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-              >
-                <option value="">All events</option>
-                {events.map((event) => (
-                  <option key={event.id} value={event.id}>
-                    {event.name}
-                  </option>
-                ))}
-              </select>
-            </label>
+        <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-4 text-sm text-gray-700">
+          <p>
+            Event: <span className="font-semibold text-gray-900">{selectedEvent?.name ?? 'Select an event'}</span>
+          </p>
+          <p>
+            Warehouse:{' '}
+            <span className="font-semibold text-gray-900">{selectedWarehouse?.name ?? 'Select a warehouse'}</span>
+          </p>
+        </div>
 
-            <label className="flex flex-col gap-2 text-sm font-medium text-gray-700">
-              Warehouse
-              <select
-                value={selectedWarehouse}
-                onChange={(event) => setSelectedWarehouse(event.target.value)}
-                className="rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-              >
-                <option value="">All warehouses</option>
-                {warehouses.map((warehouse) => (
-                  <option key={warehouse.id} value={warehouse.id}>
-                    {warehouse.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <button
-              type="button"
-              onClick={handleDownload}
-              disabled={downloading}
-              className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-3 font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
-            >
-              {downloading ? <Loader2 className="h-5 w-5 animate-spin" /> : <Download className="h-5 w-5" />}
-              {downloading ? 'Preparing export…' : 'Download CSV'}
-            </button>
-          </div>
-        )}
+        <button
+          type="button"
+          onClick={handleDownload}
+          disabled={exportMutation.isPending}
+          className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-3 font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+        >
+          {exportMutation.isPending ? <Loader2 className="h-5 w-5 animate-spin" /> : <Download className="h-5 w-5" />}
+          {exportMutation.isPending ? 'Preparing export…' : 'Download CSV'}
+        </button>
       </div>
     </div>
   );

--- a/src/components/PhotoCapture.tsx
+++ b/src/components/PhotoCapture.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useRef, useState } from 'react';
+import { Camera, ImageOff, Loader2, RefreshCcw } from 'lucide-react';
+
+export type Roi = { xPct: number; yPct: number; wPct: number; hPct: number };
+
+export const ROI_BARCODE: Roi = { xPct: 0.1, yPct: 0.55, wPct: 0.8, hPct: 0.25 };
+export const ROI_TEXT_TOP: Roi = { xPct: 0.08, yPct: 0.1, wPct: 0.84, hPct: 0.28 };
+export const ROI_LOT: Roi = { xPct: 0.08, yPct: 0.85, wPct: 0.84, hPct: 0.12 };
+
+export interface RoiCropResult {
+  barcode?: Blob;
+  textTop?: Blob;
+  lot?: Blob;
+  hints: {
+    roi: {
+      barcode: Roi;
+      textTop: Roi;
+      lot: Roi;
+    };
+    expected: {
+      barcodeSymbologies: string[];
+      keywords: string[];
+    };
+  };
+}
+
+interface PhotoCaptureProps {
+  file: File | null;
+  onChange: (file: File | null, crops: RoiCropResult | null) => void;
+  disabled?: boolean;
+}
+
+export async function getRoiCrops(file: File): Promise<RoiCropResult | null> {
+  if (typeof window === 'undefined') return null;
+
+  const hints: RoiCropResult['hints'] = {
+    roi: {
+      barcode: ROI_BARCODE,
+      textTop: ROI_TEXT_TOP,
+      lot: ROI_LOT
+    },
+    expected: {
+      barcodeSymbologies: ['ITF-14', 'EAN-13'],
+      keywords: ['RAINDANCE', 'NAMAQUA', 'FILLING DATE']
+    }
+  };
+
+  async function cropImage(image: HTMLImageElement, roi: Roi): Promise<Blob | undefined> {
+    try {
+      const canvas = document.createElement('canvas');
+      const sx = Math.floor(image.width * roi.xPct);
+      const sy = Math.floor(image.height * roi.yPct);
+      const sw = Math.floor(image.width * roi.wPct);
+      const sh = Math.floor(image.height * roi.hPct);
+      canvas.width = Math.max(1, sw);
+      canvas.height = Math.max(1, sh);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return undefined;
+      ctx.drawImage(image, sx, sy, sw, sh, 0, 0, canvas.width, canvas.height);
+      const blob = await new Promise<Blob | null>((resolve) => {
+        canvas.toBlob((value) => resolve(value), 'image/jpeg', 0.7);
+      });
+      return blob ?? undefined;
+    } catch (error) {
+      console.warn('ROI crop failed', error);
+      return undefined;
+    }
+  }
+
+  const image = await loadImage(file);
+  const [barcode, textTop, lot] = await Promise.all([
+    cropImage(image, ROI_BARCODE),
+    cropImage(image, ROI_TEXT_TOP),
+    cropImage(image, ROI_LOT)
+  ]);
+
+  if (!barcode && !textTop && !lot) {
+    return { hints };
+  }
+
+  return {
+    barcode,
+    textTop,
+    lot,
+    hints
+  };
+}
+
+async function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const image = new Image();
+    image.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(image);
+    };
+    image.onerror = (error) => {
+      URL.revokeObjectURL(url);
+      reject(error);
+    };
+    image.src = url;
+  });
+}
+
+export default function PhotoCapture({ file, onChange, disabled }: PhotoCaptureProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
+
+  useEffect(() => {
+    if (!file) {
+      setPreview(null);
+      return;
+    }
+
+    const url = URL.createObjectURL(file);
+    setPreview(url);
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [file]);
+
+  async function handleFileSelect(event: React.ChangeEvent<HTMLInputElement>) {
+    const nextFile = event.target.files?.[0] ?? null;
+    if (!nextFile) {
+      onChange(null, null);
+      return;
+    }
+
+    setProcessing(true);
+    try {
+      const crops = await getRoiCrops(nextFile);
+      onChange(nextFile, crops);
+    } catch (error) {
+      console.warn('Photo capture crop failure', error);
+      onChange(nextFile, null);
+    } finally {
+      setProcessing(false);
+    }
+  }
+
+  function handleClear() {
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+    onChange(null, null);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          disabled={disabled}
+          className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white shadow-sm transition hover:bg-blue-700 disabled:opacity-60"
+        >
+          {processing ? <Loader2 className="h-5 w-5 animate-spin" /> : <Camera className="h-5 w-5" />}
+          {processing ? 'Processing…' : 'Capture Photo'}
+        </button>
+        {file && (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-100"
+          >
+            <RefreshCcw className="h-5 w-5" />
+            Replace
+          </button>
+        )}
+      </div>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        onChange={handleFileSelect}
+        className="hidden"
+        disabled={disabled}
+      />
+
+      <div className="relative overflow-hidden rounded-xl border border-dashed border-gray-300 bg-gray-50">
+        {preview ? (
+          <>
+            <img src={preview} alt="Captured count" className="h-64 w-full object-cover" />
+            <div className="pointer-events-none absolute inset-0 flex flex-col justify-between text-white/80">
+              <div className="bg-gradient-to-b from-black/40 to-transparent p-2 text-center text-xs uppercase tracking-wider">
+                Product Text / Description
+              </div>
+              <div className="self-center rounded-full bg-black/50 px-3 py-1 text-xs uppercase tracking-wider">Barcode Area</div>
+              <div className="bg-gradient-to-t from-black/40 to-transparent p-2 text-center text-xs uppercase tracking-wider">
+                Lot / Inkjet Strip
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="flex h-64 flex-col items-center justify-center gap-3 text-gray-500">
+            <ImageOff className="h-10 w-10" />
+            <p className="text-sm">Snap a clear photo that shows the label, barcode, and lot strip.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/StocktakeEntry.tsx
+++ b/src/components/StocktakeEntry.tsx
@@ -1,10 +1,28 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { Camera, CheckCircle2, ImageOff, Loader2, RotateCcw, Upload } from 'lucide-react';
-import { useAuth } from '../contexts/AuthContext';
-import { supabase } from '../lib/supabase';
+import { useEffect, useMemo, useState } from 'react';
+import { AlertCircle, CheckCircle2, Info, Loader2 } from 'lucide-react';
+import PhotoCapture, { type RoiCropResult } from './PhotoCapture';
+import { useEventWarehouse } from '../contexts/EventWarehouseContext';
+import { useProductsLookup } from '../hooks/useProductsLookup';
+import { useSubmitCount } from '../hooks/useSubmitCount';
+import { unitsBulk, unitsPickface, unitsSingles } from '../utils/packaging';
 
-type CountMode = 'singles' | 'pick_face' | 'bulk';
-type UnitOption = 'units' | 'cases' | 'layers' | 'pallets';
+export type CountMode = 'singles' | 'pickface' | 'bulk';
+
+type UnitState = {
+  singlesUnits: string;
+  singlesCases: string;
+  pickfaceLayers: string;
+  pickfaceCases: string;
+  bulkPallets: string;
+  bulkLayers: string;
+  bulkCases: string;
+};
+
+const TAB_LABELS: Record<CountMode, string> = {
+  singles: 'Singles',
+  pickface: 'Pick Face',
+  bulk: 'Bulk'
+};
 
 interface StocktakeEntryProps {
   initialStockCode?: string;
@@ -15,21 +33,6 @@ interface StocktakeEntryProps {
   hideHeading?: boolean;
 }
 
-const COUNT_MODE_OPTIONS: Record<CountMode, { label: string; units: UnitOption[] }> = {
-  singles: {
-    label: 'Singles',
-    units: ['units', 'cases']
-  },
-  pick_face: {
-    label: 'Pick Face',
-    units: ['layers', 'cases']
-  },
-  bulk: {
-    label: 'Bulk',
-    units: ['pallets', 'layers', 'cases']
-  }
-};
-
 export default function StocktakeEntry({
   initialStockCode,
   initialLotNumber,
@@ -38,21 +41,25 @@ export default function StocktakeEntry({
   compact = false,
   hideHeading = false
 }: StocktakeEntryProps) {
-  const { user } = useAuth();
-  const [countMode, setCountMode] = useState<CountMode>('singles');
-  const [unit, setUnit] = useState<UnitOption>('units');
-  const [quantity, setQuantity] = useState('');
+  const { eventId, warehouseCode, selectedEvent, selectedWarehouse, loading: contextLoading } = useEventWarehouse();
+  const [activeTab, setActiveTab] = useState<CountMode>('singles');
   const [stockCode, setStockCode] = useState(initialStockCode ?? '');
+  const [caseBarcode, setCaseBarcode] = useState('');
+  const [unitBarcode, setUnitBarcode] = useState('');
   const [lotNumber, setLotNumber] = useState(initialLotNumber ?? '');
-  const [notes, setNotes] = useState('');
-  const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+  const [units, setUnits] = useState<UnitState>({
+    singlesUnits: '',
+    singlesCases: '',
+    pickfaceLayers: '',
+    pickfaceCases: '',
+    bulkPallets: '',
+    bulkLayers: '',
+    bulkCases: ''
+  });
   const [photoFile, setPhotoFile] = useState<File | null>(null);
-  const [submitting, setSubmitting] = useState(false);
+  const [photoCrops, setPhotoCrops] = useState<RoiCropResult | null>(null);
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const cameraInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setStockCode(initialStockCode ?? '');
@@ -62,325 +69,423 @@ export default function StocktakeEntry({
     setLotNumber(initialLotNumber ?? '');
   }, [initialLotNumber]);
 
-  useEffect(() => {
-    const availableUnits = COUNT_MODE_OPTIONS[countMode].units;
-    if (!availableUnits.includes(unit)) {
-      setUnit(availableUnits[0]);
-    }
-  }, [countMode, unit]);
+  const productQuery = useProductsLookup({ stockCode, caseBarcode, unitBarcode });
+  const product = productQuery.data as any;
 
-  const availableUnits = useMemo(() => COUNT_MODE_OPTIONS[countMode].units, [countMode]);
-
-  function handleFileSelect(event: React.ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
-    setPhotoFile(file);
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const result = reader.result as string;
-      setPhotoPreview(result);
+  const packaging = useMemo(() => {
+    return {
+      upc: typeof product?.units_per_case === 'number' ? product.units_per_case : undefined,
+      cpl: typeof product?.cases_per_layer === 'number' ? product.cases_per_layer : undefined,
+      lpp: typeof product?.layers_per_pallet === 'number' ? product.layers_per_pallet : undefined,
+      description: product?.product_name ?? product?.description ?? ''
     };
-    reader.readAsDataURL(file);
-    setErrorMessage('');
-    setSuccessMessage('');
+  }, [product]);
+
+  const submitCount = useSubmitCount();
+
+  function parseNumberInput(value: string): number | null {
+    if (!value) return null;
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) return null;
+    return Math.round(parsed);
   }
 
-  function resetPhoto() {
-    setPhotoFile(null);
-    setPhotoPreview(null);
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
+  const singlesUnitsValue = parseNumberInput(units.singlesUnits);
+  const singlesCasesValue = parseNumberInput(units.singlesCases);
+  const pickfaceLayersValue = parseNumberInput(units.pickfaceLayers);
+  const pickfaceCasesValue = parseNumberInput(units.pickfaceCases);
+  const bulkPalletsValue = parseNumberInput(units.bulkPallets);
+  const bulkLayersValue = parseNumberInput(units.bulkLayers);
+  const bulkCasesValue = parseNumberInput(units.bulkCases);
+
+  const totals = {
+    singles: unitsSingles(singlesUnitsValue ?? 0, singlesCasesValue ?? 0, packaging.upc),
+    pickface: unitsPickface(pickfaceLayersValue ?? 0, pickfaceCasesValue ?? 0, packaging.upc, packaging.cpl),
+    bulk: unitsBulk(
+      bulkPalletsValue ?? 0,
+      bulkLayersValue ?? 0,
+      bulkCasesValue ?? 0,
+      packaging.upc,
+      packaging.cpl,
+      packaging.lpp
+    )
+  };
+
+  const hasQuantity = useMemo(() => {
+    switch (activeTab) {
+      case 'singles':
+        return (singlesUnitsValue ?? 0) > 0 || (singlesCasesValue ?? 0) > 0;
+      case 'pickface':
+        return (pickfaceLayersValue ?? 0) > 0 || (pickfaceCasesValue ?? 0) > 0;
+      case 'bulk':
+        return (
+          (bulkPalletsValue ?? 0) > 0 ||
+          (bulkLayersValue ?? 0) > 0 ||
+          (bulkCasesValue ?? 0) > 0
+        );
+      default:
+        return false;
     }
-    if (cameraInputRef.current) {
-      cameraInputRef.current.value = '';
-    }
+  }, [
+    activeTab,
+    bulkCasesValue,
+    bulkLayersValue,
+    bulkPalletsValue,
+    pickfaceCasesValue,
+    pickfaceLayersValue,
+    singlesCasesValue,
+    singlesUnitsValue
+  ]);
+
+  const totalUnits = totals[activeTab];
+  const packagingComplete = {
+    singles: Boolean(packaging.upc),
+    pickface: Boolean(packaging.upc && packaging.cpl),
+    bulk: Boolean(packaging.upc && packaging.cpl && packaging.lpp)
+  };
+
+  function handlePhotoChange(file: File | null, crops: RoiCropResult | null) {
+    setPhotoFile(file);
+    setPhotoCrops(crops ?? null);
   }
 
-  function resetForm() {
-    setCountMode('singles');
-    setUnit('units');
-    setQuantity('');
-    setNotes('');
-    resetPhoto();
-    setErrorMessage('');
-    if (!initialStockCode) {
-      setStockCode('');
-    }
+  function resetQuantities() {
+    setUnits({
+      singlesUnits: '',
+      singlesCases: '',
+      pickfaceLayers: '',
+      pickfaceCases: '',
+      bulkPallets: '',
+      bulkLayers: '',
+      bulkCases: ''
+    });
+  }
+
+  function handleResetAfterSubmit() {
+    resetQuantities();
     if (!initialLotNumber) {
       setLotNumber('');
     }
+    handlePhotoChange(null, null);
   }
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!user) return;
-    if (!photoFile) {
-      setErrorMessage('A photo is required before submitting.');
+    setSuccessMessage('');
+    setErrorMessage('');
+
+    if (!eventId || !warehouseCode) {
+      setErrorMessage('Select an active event and warehouse before capturing a count.');
       return;
     }
 
-    setSubmitting(true);
-    setErrorMessage('');
+    if (!stockCode && !caseBarcode && !unitBarcode) {
+      setErrorMessage('Provide a stock code or barcode so we can match the product.');
+      return;
+    }
+
+    if (!photoFile) {
+      setErrorMessage('Capture a supporting photo before submitting.');
+      return;
+    }
+
+    if (!hasQuantity) {
+      setErrorMessage('Enter at least one quantity before submitting.');
+      return;
+    }
 
     try {
-      const {
-        data: { session }
-      } = await supabase.auth.getSession();
+      const payload = {
+        eventId,
+        warehouseCode,
+        stockCode: stockCode || undefined,
+        caseBarcode: caseBarcode || undefined,
+        unitBarcode: unitBarcode || undefined,
+        lotNumber: lotNumber || undefined,
+        photo: photoFile,
+        roiCrops: photoCrops,
+        recountTaskId
+      } as const;
 
-      if (!session?.access_token) {
-        throw new Error('Unable to authenticate request. Please sign in again.');
+      const numericPayload = { ...payload } as any;
+      if (activeTab === 'singles') {
+        numericPayload.singlesUnits = singlesUnitsValue;
+        numericPayload.singlesCases = singlesCasesValue;
+      } else if (activeTab === 'pickface') {
+        numericPayload.pickfaceLayers = pickfaceLayersValue;
+        numericPayload.pickfaceCases = pickfaceCasesValue;
+      } else {
+        numericPayload.bulkPallets = bulkPalletsValue;
+        numericPayload.bulkLayers = bulkLayersValue;
+        numericPayload.bulkCases = bulkCasesValue;
       }
 
-      const formData = new FormData();
-      formData.append('count_mode', countMode);
-      formData.append('unit', unit);
-      formData.append('quantity', quantity);
-      formData.append('stock_code', stockCode);
-      formData.append('lot_number', lotNumber);
-      formData.append('notes', notes);
-      formData.append('submitted_by', user.id);
-      if (recountTaskId) {
-        formData.append('recount_task_id', recountTaskId);
-      }
-      formData.append('photo', photoFile);
-
-      const response = await fetch(
-        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/submit-count`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${session.access_token}`
-          },
-          body: formData
-        }
-      );
-
-      if (!response.ok) {
-        const message = await response.text();
-        throw new Error(message || 'Failed to submit count.');
-      }
+      await submitCount.mutateAsync(numericPayload);
 
       setSuccessMessage('Captured ✓ — processing in background');
-      resetForm();
-      if (onSubmitSuccess) {
-        await onSubmitSuccess();
-      }
+      handleResetAfterSubmit();
+      await onSubmitSuccess?.();
     } catch (error) {
-      console.error('Error submitting count:', error);
-      setErrorMessage(error instanceof Error ? error.message : 'Failed to submit count.');
-    } finally {
-      setSubmitting(false);
+      console.error('Count submission failed', error);
+      setErrorMessage(error instanceof Error ? error.message : 'Unable to submit count');
     }
   }
 
-  const wrapperClass = compact ? '' : 'max-w-3xl mx-auto';
+  const wrapperClass = compact ? 'space-y-6' : 'max-w-3xl mx-auto space-y-6';
   const cardClass = compact ? 'space-y-6' : 'bg-white rounded-xl shadow-lg p-6 space-y-6';
 
   return (
     <div className={wrapperClass}>
       <div className={cardClass}>
-        {!hideHeading && (
-          <div className="flex flex-col gap-4">
-            <div>
-              <h2 className="text-2xl font-bold text-gray-900">Capture Count</h2>
-              <p className="text-gray-600 text-sm">Upload a count with supporting photo evidence.</p>
-            </div>
-
-            <div className="flex flex-wrap gap-3">
-              {(Object.keys(COUNT_MODE_OPTIONS) as CountMode[]).map((mode) => (
-                <button
-                  key={mode}
-                  type="button"
-                  onClick={() => setCountMode(mode)}
-                  className={`px-4 py-2 rounded-lg border transition-colors ${
-                    countMode === mode
-                      ? 'border-blue-600 bg-blue-50 text-blue-700 font-semibold'
-                      : 'border-gray-200 bg-white text-gray-700 hover:border-blue-200'
-                  }`}
-                >
-                  {COUNT_MODE_OPTIONS[mode].label}
-                </button>
-              ))}
-            </div>
+        {!hideHeading && !compact && (
+          <div className="space-y-1">
+            <h2 className="text-2xl font-bold text-gray-900">Capture Count</h2>
+            <p className="text-gray-600 text-sm">
+              Snap a photo, enter what you see, and move on. Totals update instantly and AI extraction runs in the background.
+            </p>
           </div>
         )}
 
-        {hideHeading && (
-          <div className="flex flex-wrap gap-3">
-            {(Object.keys(COUNT_MODE_OPTIONS) as CountMode[]).map((mode) => (
-              <button
-                key={mode}
-                type="button"
-                onClick={() => setCountMode(mode)}
-                className={`px-4 py-2 rounded-lg border transition-colors ${
-                  countMode === mode
-                    ? 'border-blue-600 bg-blue-50 text-blue-700 font-semibold'
-                    : 'border-gray-200 bg-white text-gray-700 hover:border-blue-200'
-                }`}
-              >
-                {COUNT_MODE_OPTIONS[mode].label}
-              </button>
-            ))}
+        <div className="rounded-lg border border-gray-200 bg-white/60 p-4 space-y-3">
+          <div className="flex flex-col gap-2 text-sm text-gray-600">
+            <div className="flex items-center gap-2 text-gray-800 font-medium">
+              <Info className="h-4 w-4 text-blue-500" />
+              Session Context
+            </div>
+            <div className="flex flex-wrap gap-3 text-xs sm:text-sm">
+              <span className="inline-flex items-center gap-2 rounded-full bg-blue-50 px-3 py-1 text-blue-700">
+                Event: {selectedEvent?.name ?? (contextLoading ? 'Loading…' : 'Select an event')}
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-emerald-700">
+                Warehouse: {selectedWarehouse?.name ?? (contextLoading ? 'Loading…' : 'Select a warehouse')}
+              </span>
+            </div>
           </div>
-        )}
+        </div>
 
         {successMessage && (
-          <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700 flex items-center gap-2">
+          <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
             <CheckCircle2 className="h-5 w-5" />
             {successMessage}
           </div>
         )}
 
         {errorMessage && (
-          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            <AlertCircle className="h-5 w-5" />
             {errorMessage}
           </div>
         )}
 
         <form onSubmit={handleSubmit} className="space-y-6">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
-              Stock Code
-              <input
-                type="text"
+          <div className="sticky top-16 z-10 space-y-3 rounded-xl border border-blue-100 bg-blue-50/80 p-4 backdrop-blur">
+            <div className="flex flex-wrap gap-3">
+              <InputField
+                label="Stock Code"
+                placeholder="e.g. SKU123"
                 value={stockCode}
-                onChange={(event) => setStockCode(event.target.value.toUpperCase())}
-                required
-                placeholder="e.g. SKU-12345"
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                onChange={(value) => setStockCode(value.toUpperCase())}
               />
-            </label>
+              <InputField
+                label="Case Barcode"
+                placeholder="Scan case barcode"
+                value={caseBarcode}
+                onChange={setCaseBarcode}
+              />
+              <InputField
+                label="Unit Barcode"
+                placeholder="Scan unit barcode"
+                value={unitBarcode}
+                onChange={setUnitBarcode}
+              />
+            </div>
 
-            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
-              Lot Number
-              <input
-                type="text"
-                value={lotNumber}
-                onChange={(event) => setLotNumber(event.target.value)}
-                required
-                placeholder="Batch or lot reference"
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-              />
-            </label>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wider text-blue-700">Packaging Factors</p>
+                <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                  <Chip label="Units / Case" value={packaging.upc ? `${packaging.upc}` : '—'} />
+                  <Chip label="Cases / Layer" value={packaging.cpl ? `${packaging.cpl}` : '—'} />
+                  <Chip label="Layers / Pallet" value={packaging.lpp ? `${packaging.lpp}` : '—'} />
+                </div>
+              </div>
+              <div className="text-right text-xs text-gray-600">
+                {productQuery.isLoading ? 'Looking up product…' : packaging.description || 'Awaiting identification'}
+              </div>
+            </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
-              Quantity
-              <input
-                type="number"
-                min="0"
-                step="1"
-                value={quantity}
-                onChange={(event) => setQuantity(event.target.value)}
-                required
-                placeholder="Enter amount counted"
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-              />
-            </label>
+          <PhotoCapture file={photoFile} onChange={handlePhotoChange} />
 
-            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
-              Unit
-              <select
-                value={unit}
-                onChange={(event) => setUnit(event.target.value as UnitOption)}
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-              >
-                {availableUnits.map((option) => (
-                  <option key={option} value={option}>
-                    {option.charAt(0).toUpperCase() + option.slice(1)}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700 md:col-span-1 md:col-start-auto">
-              Notes
-              <input
-                type="text"
-                value={notes}
-                onChange={(event) => setNotes(event.target.value)}
-                placeholder="Optional comments"
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-              />
-            </label>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700">Lot number (optional)</label>
+            <input
+              type="text"
+              value={lotNumber}
+              onChange={(event) => setLotNumber(event.target.value)}
+              placeholder="Lot / batch reference"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            />
           </div>
 
           <div className="space-y-4">
-            <div className="flex gap-3 flex-wrap">
-              <button
-                type="button"
-                onClick={() => cameraInputRef.current?.click()}
-                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white shadow-sm transition hover:bg-blue-700"
-              >
-                <Camera className="h-5 w-5" />
-                Take Photo
-              </button>
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                className="inline-flex items-center gap-2 rounded-lg bg-gray-600 px-4 py-2 text-white shadow-sm transition hover:bg-gray-700"
-              >
-                <Upload className="h-5 w-5" />
-                Upload Photo
-              </button>
-              {photoPreview && (
+            <div className="flex flex-wrap gap-2">
+              {(Object.keys(TAB_LABELS) as CountMode[]).map((tab) => (
                 <button
+                  key={tab}
                   type="button"
-                  onClick={resetPhoto}
-                  className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-100"
+                  onClick={() => setActiveTab(tab)}
+                  className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                    activeTab === tab
+                      ? 'bg-blue-600 text-white shadow-sm'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  }`}
                 >
-                  <RotateCcw className="h-5 w-5" />
-                  Retake
+                  {TAB_LABELS[tab]}
                 </button>
-              )}
+              ))}
             </div>
 
-            <input
-              ref={cameraInputRef}
-              type="file"
-              accept="image/*"
-              capture="environment"
-              onChange={handleFileSelect}
-              className="hidden"
-            />
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              onChange={handleFileSelect}
-              className="hidden"
-            />
+            {activeTab === 'singles' && (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <NumberField
+                  label="Units"
+                  value={units.singlesUnits}
+                  onChange={(value) => setUnits((prev) => ({ ...prev, singlesUnits: value }))}
+                />
+                <NumberField
+                  label="Cases"
+                  value={units.singlesCases}
+                  onChange={(value) => setUnits((prev) => ({ ...prev, singlesCases: value }))}
+                />
+              </div>
+            )}
 
-            <div className="overflow-hidden rounded-lg border border-dashed border-gray-300 bg-gray-50">
-              {photoPreview ? (
-                <img src={photoPreview} alt="Count evidence" className="h-64 w-full object-contain bg-white" />
-              ) : (
-                <div className="flex h-64 flex-col items-center justify-center gap-2 text-gray-500">
-                  <ImageOff className="h-10 w-10" />
-                  <p className="text-sm">No photo selected yet</p>
-                </div>
-              )}
-            </div>
+            {activeTab === 'pickface' && (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <NumberField
+                  label="Layers"
+                  value={units.pickfaceLayers}
+                  onChange={(value) => setUnits((prev) => ({ ...prev, pickfaceLayers: value }))}
+                />
+                <NumberField
+                  label="Cases"
+                  value={units.pickfaceCases}
+                  onChange={(value) => setUnits((prev) => ({ ...prev, pickfaceCases: value }))}
+                />
+                <TotalPill value={totalUnits} label="Total Units" />
+              </div>
+            )}
+
+            {activeTab === 'bulk' && (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+                <NumberField
+                  label="Full Pallets"
+                  value={units.bulkPallets}
+                  onChange={(value) => setUnits((prev) => ({ ...prev, bulkPallets: value }))}
+                />
+                <NumberField
+                  label="Layers"
+                  value={units.bulkLayers}
+                  onChange={(value) => setUnits((prev) => ({ ...prev, bulkLayers: value }))}
+                />
+                <NumberField
+                  label="Cases"
+                  value={units.bulkCases}
+                  onChange={(value) => setUnits((prev) => ({ ...prev, bulkCases: value }))}
+                />
+                <TotalPill value={totalUnits} label="Total Units" />
+              </div>
+            )}
+
+            {activeTab === 'singles' && (
+              <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm">
+                <span className="font-medium text-gray-700">Total Units</span>
+                <span className="text-lg font-semibold text-gray-900">{totalUnits}</span>
+              </div>
+            )}
+
+            {!packagingComplete[activeTab] && (
+              <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                We&apos;ll calculate the missing conversions once packaging data is available. Submit anyway to keep moving.
+              </div>
+            )}
           </div>
 
           <button
             type="submit"
-            disabled={submitting || !stockCode || !lotNumber || !quantity || !photoFile}
-            className="w-full inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-3 text-white font-semibold shadow-sm transition enabled:hover:bg-blue-700 disabled:opacity-60"
+            disabled={submitCount.isPending || !hasQuantity || !eventId || !warehouseCode || !photoFile}
+            className="sticky bottom-4 w-full rounded-lg bg-blue-600 px-4 py-3 text-lg font-semibold text-white shadow-lg transition enabled:hover:bg-blue-700 disabled:opacity-60"
           >
-            {submitting ? (
-              <>
-                <Loader2 className="h-5 w-5 animate-spin" />
-                Capturing...
-              </>
+            {submitCount.isPending ? (
+              <span className="flex items-center justify-center gap-2">
+                <Loader2 className="h-5 w-5 animate-spin" /> Capturing…
+              </span>
             ) : (
-              'Submit Count'
+              'Submit count'
             )}
           </button>
         </form>
       </div>
     </div>
+  );
+}
+
+function NumberField({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) {
+  return (
+    <label className="flex flex-col gap-2 text-sm font-medium text-gray-700">
+      {label}
+      <input
+        type="number"
+        min={0}
+        step={1}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+      />
+    </label>
+  );
+}
+
+function TotalPill({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex flex-col justify-center rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-center text-sm text-blue-700">
+      <span className="text-xs uppercase tracking-wide text-blue-600">{label}</span>
+      <span className="text-lg font-semibold text-blue-800">{value}</span>
+    </div>
+  );
+}
+
+function Chip({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-white px-3 py-1 text-xs text-blue-700">
+      <span className="font-semibold uppercase tracking-wide text-blue-600">{label}</span>
+      <span>{value}</span>
+    </span>
+  );
+}
+
+function InputField({
+  label,
+  value,
+  onChange,
+  placeholder
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+}) {
+  return (
+    <label className="flex flex-1 min-w-[160px] flex-col gap-2 text-sm font-medium text-gray-700">
+      {label}
+      <input
+        type="text"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="rounded-lg border border-blue-200 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+      />
+    </label>
   );
 }

--- a/src/components/VarianceReports.tsx
+++ b/src/components/VarianceReports.tsx
@@ -1,124 +1,20 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { AlertTriangle, CheckCircle, Download, Loader2 } from 'lucide-react';
-import { supabase } from '../lib/supabase';
-import { useAuth } from '../contexts/AuthContext';
-
-type VarianceRow = {
-  id: string;
-  description: string;
-  lot: string;
-  variance: number;
-  warehouse_id: string;
-  warehouse_name?: string | null;
-  event_name?: string | null;
-  product_code?: string | null;
-  created_at?: string;
-};
-
-type WarehouseAssignment = {
-  warehouse_id: string;
-  warehouse?: { id: string; name: string } | null;
-};
+import { useMemo, useState } from 'react';
+import { AlertCircle, ClipboardList, Loader2, RefreshCcw } from 'lucide-react';
+import { useEventWarehouse } from '../contexts/EventWarehouseContext';
+import { useVariance } from '../hooks/useVariance';
+import { useAssignRecounts } from '../hooks/useAssignRecounts';
 
 export default function VarianceReports() {
-  const { profile } = useAuth();
-  const [rows, setRows] = useState<VarianceRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
-  const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [assigning, setAssigning] = useState(false);
-  const [warehouses, setWarehouses] = useState<WarehouseAssignment[]>([]);
-  const [assignedWarehouseIds, setAssignedWarehouseIds] = useState<string[]>([]);
+  const { eventId, warehouseCode, selectedEvent, selectedWarehouse } = useEventWarehouse();
+  const varianceQuery = useVariance(eventId, warehouseCode);
+  const assignMutation = useAssignRecounts();
+  const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
 
-  const warehouseOptions = useMemo(() => {
-    return warehouses
-      .map((assignment) => assignment.warehouse)
-      .filter((w): w is { id: string; name: string } => Boolean(w));
-  }, [warehouses]);
+  const rows = useMemo(() => varianceQuery.data ?? [], [varianceQuery.data]);
+  const nothingSelected = selectedRows.size === 0;
 
-  const canAssign = selected.size > 0 && !assigning;
-
-  const loadWarehouses = useCallback(async () => {
-    if (!profile) {
-      setWarehouses([]);
-      setAssignedWarehouseIds([]);
-      return [];
-    }
-
-    try {
-      const { data, error: queryError } = await supabase
-        .from('user_warehouse_assignments')
-        .select('warehouse_id, warehouses(id, name)')
-        .eq('user_id', profile.id);
-
-      if (queryError) throw queryError;
-
-      const normalized: WarehouseAssignment[] = (data ?? []).map((assignment: any) => ({
-        warehouse_id: assignment.warehouse_id as string,
-        warehouse: Array.isArray(assignment.warehouses)
-          ? assignment.warehouses[0] ?? null
-          : assignment.warehouses ?? null
-      }));
-
-      setWarehouses(normalized);
-      const ids = normalized
-        .map((assignment) => assignment.warehouse_id)
-        .filter((id): id is string => Boolean(id));
-      setAssignedWarehouseIds(ids);
-      return ids;
-    } catch (err) {
-      console.error('Error loading warehouse assignments:', err);
-      setError(err instanceof Error ? err.message : 'Unable to load warehouse assignments.');
-      return [];
-    }
-  }, [profile]);
-
-  const loadVariance = useCallback(
-    async (ids: string[]) => {
-      if (ids.length === 0) {
-        setRows([]);
-        setLoading(false);
-        return;
-      }
-
-      try {
-        setLoading(true);
-        setError('');
-        const { data, error: queryError } = await supabase
-          .from('manager_variance_view')
-          .select('*')
-          .in('warehouse_id', ids)
-          .order('created_at', { ascending: false });
-
-        if (queryError) throw queryError;
-        const typedRows = (data ?? []) as VarianceRow[];
-        setRows(typedRows);
-      } catch (err) {
-        console.error('Error loading variance view:', err);
-        setError(err instanceof Error ? err.message : 'Failed to load variance data.');
-      } finally {
-        setLoading(false);
-      }
-    },
-    []
-  );
-
-  useEffect(() => {
-    async function initialise() {
-      const ids = await loadWarehouses();
-      if (ids.length > 0) {
-        await loadVariance(ids);
-      } else {
-        setLoading(false);
-        setRows([]);
-      }
-    }
-
-    initialise();
-  }, [loadVariance, loadWarehouses]);
-
-  function toggleSelection(id: string) {
-    setSelected((prev) => {
+  function toggleRow(id: string) {
+    setSelectedRows((prev) => {
       const next = new Set(prev);
       if (next.has(id)) {
         next.delete(id);
@@ -129,144 +25,116 @@ export default function VarianceReports() {
     });
   }
 
-  async function handleAssignRecounts() {
-    if (selected.size === 0) return;
-    setAssigning(true);
-    setError('');
+  async function handleAssign() {
+    if (!eventId || !warehouseCode || nothingSelected) return;
+    const items = rows
+      .filter((row) => selectedRows.has(row.stock_code ?? `${row.description}-${row.lot_number}`))
+      .filter((row) => Boolean(row.stock_code))
+      .map((row) => ({
+        stock_code: row.stock_code as string,
+        lot_number: row.lot_number
+      }));
+
+    if (items.length === 0) return;
 
     try {
-      const {
-        data: { session }
-      } = await supabase.auth.getSession();
-
-      if (!session?.access_token) {
-        throw new Error('Unable to authenticate assign request.');
-      }
-
-      const response = await fetch(
-        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/assign-recounts`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session.access_token}`
-          },
-          body: JSON.stringify({ variance_ids: Array.from(selected) })
-        }
-      );
-
-      if (!response.ok) {
-        const message = await response.text();
-        throw new Error(message || 'Failed to assign recounts.');
-      }
-
-      setSelected(new Set());
-      if (assignedWarehouseIds.length > 0) {
-        await loadVariance(assignedWarehouseIds);
-      }
-    } catch (err) {
-      console.error('Error assigning recounts:', err);
-      setError(err instanceof Error ? err.message : 'Failed to assign recounts.');
-    } finally {
-      setAssigning(false);
+      await assignMutation.mutateAsync({ eventId, warehouseCode, items });
+      setSelectedRows(new Set());
+      await varianceQuery.refetch();
+    } catch (error) {
+      console.error('Failed to assign recounts', error);
     }
   }
 
-  if (loading) {
-    return (
-      <div className="max-w-6xl mx-auto">
-        <div className="bg-white rounded-xl shadow-lg p-8 text-center">
-          <Loader2 className="mx-auto h-10 w-10 animate-spin text-blue-600" />
-          <p className="mt-3 text-gray-600">Loading variance data…</p>
-        </div>
-      </div>
-    );
-  }
+  const isLoading = varianceQuery.isLoading;
+  const error = varianceQuery.error;
 
   return (
     <div className="max-w-6xl mx-auto space-y-6">
-      <div className="bg-white rounded-xl shadow-lg p-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-2xl font-bold text-gray-900">Variance Overview</h2>
-            <p className="text-gray-600 text-sm">
-              Review stock variances across your assigned warehouses. Select rows to trigger recount tasks.
-            </p>
-          </div>
+      <div className="bg-white rounded-xl shadow-lg p-6 space-y-4">
+        <div className="flex flex-col gap-2">
+          <h2 className="flex items-center gap-2 text-2xl font-bold text-gray-900">
+            <ClipboardList className="h-6 w-6 text-blue-600" /> Variance Overview
+          </h2>
+          <p className="text-sm text-gray-600">
+            Review variances for <strong>{selectedEvent?.name ?? '…'}</strong> in{' '}
+            <strong>{selectedWarehouse?.name ?? '…'}</strong>. Select rows to trigger recount tasks.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <button
             type="button"
-            onClick={handleAssignRecounts}
-            disabled={!canAssign}
-            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+            onClick={() => varianceQuery.refetch()}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-700 transition hover:bg-gray-50"
           >
-            {assigning ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
-            Assign Recounts
+            <RefreshCcw className="h-4 w-4" /> Refresh
+          </button>
+
+          <button
+            type="button"
+            onClick={handleAssign}
+            disabled={nothingSelected || assignMutation.isPending || !eventId || !warehouseCode}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+          >
+            {assignMutation.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" /> Assigning…
+              </>
+            ) : (
+              'Assign recounts'
+            )}
           </button>
         </div>
 
         {error && (
-          <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+          <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            <AlertCircle className="h-4 w-4" /> {error.message}
+          </div>
         )}
 
-        {rows.length === 0 ? (
-          <div className="mt-6 flex flex-col items-center justify-center gap-3 py-10 text-gray-600">
-            <CheckCircle className="h-10 w-10 text-green-500" />
-            <p className="text-base font-medium">No variances detected for your warehouses.</p>
+        {isLoading ? (
+          <div className="flex flex-col items-center justify-center gap-3 py-12 text-gray-600">
+            <Loader2 className="h-8 w-8 animate-spin text-blue-600" /> Loading variance data…
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-6 text-center text-sm text-gray-600">
+            No variances to show for this selection.
           </div>
         ) : (
-          <div className="mt-6 overflow-hidden rounded-lg border border-gray-200">
+          <div className="overflow-hidden rounded-lg border border-gray-200">
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
-                    <span className="sr-only">Select</span>
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
-                    Description
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">Lot</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
-                    Variance
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
-                    Warehouse
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
-                    Event
-                  </th>
+                <tr className="text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                  <th className="px-4 py-3">Select</th>
+                  <th className="px-4 py-3">Description</th>
+                  <th className="px-4 py-3">Lot Number</th>
+                  <th className="px-4 py-3 text-right">Variance Units</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200 bg-white">
+              <tbody className="divide-y divide-gray-100 bg-white">
                 {rows.map((row) => {
-                  const isSelected = selected.has(row.id);
-                  const varianceClass = row.variance === 0 ? 'text-gray-600' : row.variance > 0 ? 'text-green-600' : 'text-red-600';
+                  const id = row.stock_code ?? `${row.description}-${row.lot_number}`;
+                  const isSelected = selectedRows.has(id);
                   return (
-                    <tr key={row.id} className={isSelected ? 'bg-blue-50' : undefined}>
+                    <tr key={id} className={isSelected ? 'bg-blue-50' : undefined}>
                       <td className="px-4 py-3">
                         <input
                           type="checkbox"
                           checked={isSelected}
-                          onChange={() => toggleSelection(row.id)}
+                          onChange={() => toggleRow(id)}
                           className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                         />
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-900">
-                        <div className="font-semibold">{row.description}</div>
-                        {row.product_code && (
-                          <div className="text-xs text-gray-500">Code: {row.product_code}</div>
-                        )}
+                      <td className="px-4 py-3 text-sm text-gray-800">{row.description}</td>
+                      <td className="px-4 py-3 text-sm text-gray-600">{row.lot_number}</td>
+                      <td
+                        className={`px-4 py-3 text-right text-sm font-semibold ${
+                          row.variance_units < 0 ? 'text-red-600' : 'text-emerald-600'
+                        }`}
+                      >
+                        {row.variance_units}
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-700">{row.lot || '—'}</td>
-                      <td className={`px-4 py-3 text-sm font-semibold ${varianceClass}`}>
-                        <div className="flex items-center gap-2">
-                          {row.variance === 0 ? <CheckCircle className="h-4 w-4" /> : <AlertTriangle className="h-4 w-4" />}
-                          {row.variance}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-sm text-gray-700">
-                        {row.warehouse_name || warehouseOptions.find((w) => w.id === row.warehouse_id)?.name || '—'}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-gray-700">{row.event_name || '—'}</td>
                     </tr>
                   );
                 })}

--- a/src/contexts/EventWarehouseContext.tsx
+++ b/src/contexts/EventWarehouseContext.tsx
@@ -1,0 +1,186 @@
+import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from './AuthContext';
+
+const EVENT_STORAGE_KEY = 'nb-stocktake:selected-event';
+const WAREHOUSE_STORAGE_KEY = 'nb-stocktake:selected-warehouse';
+
+export interface EventOption {
+  id: string;
+  name: string;
+  status?: string | null;
+  starts_at?: string | null;
+  ends_at?: string | null;
+}
+
+export interface WarehouseOption {
+  id: string;
+  code: string;
+  name: string;
+}
+
+interface EventWarehouseContextValue {
+  events: EventOption[];
+  warehouses: WarehouseOption[];
+  eventId?: string;
+  warehouseCode?: string;
+  loading: boolean;
+  setEventId: (value: string) => void;
+  setWarehouseCode: (value: string) => void;
+  selectedEvent?: EventOption;
+  selectedWarehouse?: WarehouseOption;
+}
+
+const EventWarehouseContext = createContext<EventWarehouseContextValue | undefined>(undefined);
+
+function getStoredValue(key: string) {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    return window.localStorage.getItem(key) ?? undefined;
+  } catch (error) {
+    console.warn('Failed to read storage value', error);
+    return undefined;
+  }
+}
+
+function setStoredValue(key: string, value: string) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (error) {
+    console.warn('Failed to persist storage value', error);
+  }
+}
+
+export function EventWarehouseProvider({ children }: { children: ReactNode }) {
+  const { profile } = useAuth();
+  const [events, setEvents] = useState<EventOption[]>([]);
+  const [warehouses, setWarehouses] = useState<WarehouseOption[]>([]);
+  const [eventId, setEventIdState] = useState<string | undefined>(() => getStoredValue(EVENT_STORAGE_KEY));
+  const [warehouseCode, setWarehouseCodeState] = useState<string | undefined>(() => getStoredValue(WAREHOUSE_STORAGE_KEY));
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadEvents() {
+      try {
+        const { data, error } = await supabase
+          .from('stocktake_events')
+          .select('id, name, status, starts_at, ends_at')
+          .order('starts_at', { ascending: false });
+
+        if (error) throw error;
+        const mapped = (data ?? []).map((row) => ({
+          id: row.id as string,
+          name: (row.name as string) ?? 'Unnamed event',
+          status: (row.status as string | null) ?? null,
+          starts_at: (row.starts_at as string | null) ?? null,
+          ends_at: (row.ends_at as string | null) ?? null
+        }));
+        setEvents(mapped);
+        if (mapped.length > 0 && !eventId) {
+          setEventIdState(mapped[0].id);
+        }
+      } catch (error) {
+        console.error('Failed to load events', error);
+        setEvents([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadEvents();
+  }, [eventId]);
+
+  useEffect(() => {
+    async function loadWarehouses() {
+      if (!profile) {
+        setWarehouses([]);
+        return;
+      }
+
+      try {
+        const { data, error } = await supabase
+          .from('warehouses')
+          .select('id, code, name')
+          .order('name', { ascending: true });
+
+        if (error) throw error;
+        let mapped = (data ?? []).map((row) => ({
+          id: row.id as string,
+          code: (row.code as string) ?? row.id,
+          name: (row.name as string) ?? row.code ?? row.id
+        }));
+
+        if (profile.role === 'stocktaker') {
+          const { data: assignments, error: assignmentError } = await supabase
+            .from('user_warehouse_assignments')
+            .select('warehouse_code')
+            .eq('user_id', profile.id);
+
+          if (assignmentError) throw assignmentError;
+          const assignedCodes = new Set(
+            (assignments ?? [])
+              .map((assignment) => assignment.warehouse_code as string | undefined)
+              .filter((code): code is string => Boolean(code))
+          );
+          if (assignedCodes.size > 0) {
+            mapped = mapped.filter((warehouse) => assignedCodes.has(warehouse.code));
+          }
+        }
+
+        setWarehouses(mapped);
+        if (mapped.length > 0 && !warehouseCode) {
+          setWarehouseCodeState(mapped[0].code);
+        }
+      } catch (error) {
+        console.error('Failed to load warehouses', error);
+        setWarehouses([]);
+      }
+    }
+
+    loadWarehouses();
+  }, [profile, warehouseCode]);
+
+  useEffect(() => {
+    if (eventId) {
+      setStoredValue(EVENT_STORAGE_KEY, eventId);
+    }
+  }, [eventId]);
+
+  useEffect(() => {
+    if (warehouseCode) {
+      setStoredValue(WAREHOUSE_STORAGE_KEY, warehouseCode);
+    }
+  }, [warehouseCode]);
+
+  const selectedEvent = useMemo(() => events.find((event) => event.id === eventId), [events, eventId]);
+  const selectedWarehouse = useMemo(
+    () => warehouses.find((warehouse) => warehouse.code === warehouseCode),
+    [warehouseCode, warehouses]
+  );
+
+  const value = useMemo<EventWarehouseContextValue>(
+    () => ({
+      events,
+      warehouses,
+      eventId,
+      warehouseCode,
+      loading,
+      selectedEvent,
+      selectedWarehouse,
+      setEventId: setEventIdState,
+      setWarehouseCode: setWarehouseCodeState
+    }),
+    [eventId, events, loading, selectedEvent, selectedWarehouse, warehouseCode, warehouses]
+  );
+
+  return <EventWarehouseContext.Provider value={value}>{children}</EventWarehouseContext.Provider>;
+}
+
+export function useEventWarehouse() {
+  const context = useContext(EventWarehouseContext);
+  if (!context) {
+    throw new Error('useEventWarehouse must be used within an EventWarehouseProvider');
+  }
+  return context;
+}

--- a/src/hooks/useAssignRecounts.ts
+++ b/src/hooks/useAssignRecounts.ts
@@ -1,0 +1,46 @@
+import { useMutation } from '../lib/queryClient';
+import { useSupabaseClientWithAuth } from './useSupabaseClientWithAuth';
+
+export interface AssignRecountItem {
+  stock_code: string;
+  lot_number: string;
+}
+
+export interface AssignRecountsPayload {
+  eventId: string;
+  warehouseCode: string;
+  items: AssignRecountItem[];
+}
+
+interface AssignRecountResponse {
+  ok: boolean;
+  created: number;
+}
+
+export function useAssignRecounts() {
+  const { fetchWithAuth } = useSupabaseClientWithAuth();
+
+  return useMutation<AssignRecountResponse, AssignRecountsPayload>({
+    mutationFn: async ({ eventId, warehouseCode, items }) => {
+      const url = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/assign-recounts`;
+      const response = await fetchWithAuth(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          event_id: eventId,
+          warehouse_code: warehouseCode,
+          items
+        })
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Failed to assign recounts');
+      }
+
+      return response.json();
+    }
+  });
+}

--- a/src/hooks/useExportCounts.ts
+++ b/src/hooks/useExportCounts.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '../lib/queryClient';
+import { useSupabaseClientWithAuth } from './useSupabaseClientWithAuth';
+
+interface ExportCountsPayload {
+  eventId: string;
+  warehouseCode: string;
+}
+
+export function useExportCounts() {
+  const { fetchWithAuth } = useSupabaseClientWithAuth();
+
+  return useMutation<Blob, ExportCountsPayload>({
+    mutationFn: async ({ eventId, warehouseCode }) => {
+      const params = new URLSearchParams({ event_id: eventId, warehouse_code: warehouseCode });
+      const url = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/export-counts?${params.toString()}`;
+      const response = await fetchWithAuth(url, { method: 'GET' });
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Failed to export counts');
+      }
+      return response.blob();
+    }
+  });
+}

--- a/src/hooks/useProductsLookup.ts
+++ b/src/hooks/useProductsLookup.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import { useQuery } from '../lib/queryClient';
+import { supabase } from '../lib/supabase';
+
+export interface ProductLookupInput {
+  stockCode?: string;
+  caseBarcode?: string;
+  unitBarcode?: string;
+}
+
+export function useProductsLookup(input: ProductLookupInput) {
+  const normalised = useMemo(() => {
+    return {
+      stockCode: input.stockCode?.trim() ?? '',
+      caseBarcode: input.caseBarcode?.trim() ?? '',
+      unitBarcode: input.unitBarcode?.trim() ?? ''
+    };
+  }, [input.caseBarcode, input.stockCode, input.unitBarcode]);
+
+  return useQuery({
+    queryKey: ['product-lookup', normalised.stockCode, normalised.caseBarcode, normalised.unitBarcode],
+    enabled: Boolean(normalised.stockCode || normalised.caseBarcode || normalised.unitBarcode),
+    queryFn: async () => {
+      if (!normalised.stockCode && !normalised.caseBarcode && !normalised.unitBarcode) {
+        return null;
+      }
+
+      let query = supabase.from('products').select('*').limit(1);
+      if (normalised.stockCode) {
+        query = query.eq('stock_code', normalised.stockCode);
+      } else if (normalised.caseBarcode) {
+        query = query.eq('case_barcode', normalised.caseBarcode);
+      } else if (normalised.unitBarcode) {
+        query = query.eq('unit_barcode', normalised.unitBarcode);
+      }
+
+      const { data, error } = await query.maybeSingle();
+      if (error) throw error;
+      return data;
+    }
+  });
+}

--- a/src/hooks/useSubmitCount.ts
+++ b/src/hooks/useSubmitCount.ts
@@ -1,0 +1,89 @@
+import { useMutation } from '../lib/queryClient';
+import { useSupabaseClientWithAuth } from './useSupabaseClientWithAuth';
+import type { RoiCropResult } from '../components/PhotoCapture';
+
+export interface SubmitCountPayload {
+  eventId: string;
+  warehouseCode: string;
+  stockCode?: string;
+  caseBarcode?: string;
+  unitBarcode?: string;
+  recountTaskId?: string;
+  singlesUnits?: number | null;
+  singlesCases?: number | null;
+  pickfaceLayers?: number | null;
+  pickfaceCases?: number | null;
+  bulkPallets?: number | null;
+  bulkLayers?: number | null;
+  bulkCases?: number | null;
+  lotNumber?: string;
+  photo?: File | null;
+  roiCrops?: RoiCropResult | null;
+}
+
+interface SubmitCountResponse {
+  ok: boolean;
+  id: string;
+  total_units: number;
+  photo_path?: string;
+}
+
+export function useSubmitCount() {
+  const { fetchWithAuth } = useSupabaseClientWithAuth();
+  const mutation = useMutation<SubmitCountResponse, SubmitCountPayload>({
+    mutationFn: async (payload) => {
+      const url = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/submit-count`;
+      const formData = new FormData();
+      formData.append('event_id', payload.eventId);
+      formData.append('warehouse_code', payload.warehouseCode);
+      if (payload.stockCode) formData.append('stock_code', payload.stockCode);
+      if (payload.caseBarcode) formData.append('case_barcode', payload.caseBarcode);
+      if (payload.unitBarcode) formData.append('unit_barcode', payload.unitBarcode);
+      if (payload.recountTaskId) formData.append('recount_task_id', payload.recountTaskId);
+
+      appendNumber(formData, 'singles_units', payload.singlesUnits);
+      appendNumber(formData, 'singles_cases', payload.singlesCases);
+      appendNumber(formData, 'pickface_layers', payload.pickfaceLayers);
+      appendNumber(formData, 'pickface_cases', payload.pickfaceCases);
+      appendNumber(formData, 'bulk_pallets', payload.bulkPallets);
+      appendNumber(formData, 'bulk_layers', payload.bulkLayers);
+      appendNumber(formData, 'bulk_cases', payload.bulkCases);
+
+      if (payload.lotNumber) {
+        formData.append('lot_number', payload.lotNumber);
+      }
+
+      if (payload.photo) {
+        formData.append('photo', payload.photo);
+      }
+
+      if (payload.roiCrops) {
+        const { barcode, textTop, lot, hints } = payload.roiCrops;
+        if (barcode) formData.append('photo_roi_barcode', barcode, 'roi-barcode.jpg');
+        if (textTop) formData.append('photo_roi_text_top', textTop, 'roi-text-top.jpg');
+        if (lot) formData.append('photo_roi_lot', lot, 'roi-lot.jpg');
+        if (hints) formData.append('hints', JSON.stringify(hints));
+      }
+
+      const response = await fetchWithAuth(url, {
+        method: 'POST',
+        body: formData
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Unable to submit count');
+      }
+
+      return response.json();
+    }
+  });
+
+  return mutation;
+}
+
+function appendNumber(formData: FormData, key: string, value: number | null | undefined) {
+  if (value === null || value === undefined) return;
+  if (Number.isNaN(value)) return;
+  formData.append(key, String(value));
+}

--- a/src/hooks/useSupabaseClientWithAuth.ts
+++ b/src/hooks/useSupabaseClientWithAuth.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+
+export function useSupabaseClientWithAuth() {
+  const fetchWithAuth = useCallback(async (input: string, init: RequestInit = {}) => {
+    const { data } = await supabase.auth.getSession();
+    const token = data.session?.access_token;
+    const headers = new Headers(init.headers ?? {});
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+    return fetch(input, { ...init, headers });
+  }, []);
+
+  return { supabase, fetchWithAuth };
+}

--- a/src/hooks/useVariance.ts
+++ b/src/hooks/useVariance.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '../lib/queryClient';
+import { supabase } from '../lib/supabase';
+
+export interface VarianceRow {
+  stock_code?: string | null;
+  description: string;
+  lot_number: string;
+  variance_units: number;
+  event_id: string;
+  warehouse_code: string;
+}
+
+export function useVariance(eventId?: string, warehouseCode?: string) {
+  return useQuery({
+    queryKey: ['variance', eventId, warehouseCode],
+    enabled: Boolean(eventId && warehouseCode),
+    queryFn: async () => {
+      if (!eventId || !warehouseCode) return [] as VarianceRow[];
+      const { data, error } = await supabase
+        .from('manager_variance_view')
+        .select('stock_code, description, lot_number, variance_units, event_id, warehouse_code')
+        .eq('event_id', eventId)
+        .eq('warehouse_code', warehouseCode)
+        .order('variance_units', { ascending: true });
+
+      if (error) throw error;
+      return (data ?? []) as VarianceRow[];
+    }
+  });
+}

--- a/src/lib/queryClient.tsx
+++ b/src/lib/queryClient.tsx
@@ -1,0 +1,194 @@
+import { createContext, type PropsWithChildren, useCallback, useContext, useEffect, useRef, useState } from 'react';
+
+type QueryKey = unknown[] | readonly unknown[] | string;
+
+type QueryOptions<TData> = {
+  queryKey: QueryKey;
+  queryFn: () => Promise<TData> | TData;
+  enabled?: boolean;
+};
+
+type QueryResult<TData> = {
+  data: TData | undefined;
+  error: Error | null;
+  isLoading: boolean;
+  refetch: () => Promise<TData | undefined>;
+};
+
+type MutationOptions<TData, TVariables> = {
+  mutationFn: (variables: TVariables) => Promise<TData> | TData;
+  onSuccess?: (data: TData, variables: TVariables) => void;
+  onError?: (error: Error, variables: TVariables) => void;
+};
+
+type MutationResult<TData, TVariables> = {
+  mutate: (variables: TVariables) => Promise<TData>;
+  mutateAsync: (variables: TVariables) => Promise<TData>;
+  data: TData | undefined;
+  error: Error | null;
+  isPending: boolean;
+};
+
+function normaliseKey(key: QueryKey): string {
+  return typeof key === 'string' ? key : JSON.stringify(key);
+}
+
+class InMemoryCache {
+  private store = new Map<string, unknown>();
+
+  get<T>(key: QueryKey): T | undefined {
+    return this.store.get(normaliseKey(key)) as T | undefined;
+  }
+
+  set<T>(key: QueryKey, value: T) {
+    this.store.set(normaliseKey(key), value);
+  }
+
+  delete(key: QueryKey) {
+    this.store.delete(normaliseKey(key));
+  }
+
+  keys() {
+    return Array.from(this.store.keys());
+  }
+}
+
+export class QueryClient {
+  private cache = new InMemoryCache();
+  private listeners = new Map<string, Set<() => void>>();
+
+  getQueryData<T>(key: QueryKey): T | undefined {
+    return this.cache.get<T>(key);
+  }
+
+  setQueryData<T>(key: QueryKey, value: T) {
+    this.cache.set(key, value);
+    this.emit(key);
+  }
+
+  invalidateQueries(predicate?: (key: string) => boolean) {
+    for (const key of this.cache.keys()) {
+      if (!predicate || predicate(key)) {
+        this.emit(key);
+      }
+    }
+  }
+
+  subscribe(key: QueryKey, listener: () => void) {
+    const normalised = normaliseKey(key);
+    if (!this.listeners.has(normalised)) {
+      this.listeners.set(normalised, new Set());
+    }
+    this.listeners.get(normalised)!.add(listener);
+    return () => {
+      const set = this.listeners.get(normalised);
+      if (!set) return;
+      set.delete(listener);
+      if (set.size === 0) {
+        this.listeners.delete(normalised);
+      }
+    };
+  }
+
+  private emit(key: QueryKey) {
+    const listeners = this.listeners.get(normaliseKey(key));
+    listeners?.forEach((listener) => listener());
+  }
+}
+
+const QueryClientContext = createContext<QueryClient | null>(null);
+
+export function QueryClientProvider({ client, children }: PropsWithChildren<{ client: QueryClient }>) {
+  return <QueryClientContext.Provider value={client}>{children}</QueryClientContext.Provider>;
+}
+
+export function useQueryClient() {
+  const context = useContext(QueryClientContext);
+  if (!context) {
+    throw new Error('useQueryClient must be used within a QueryClientProvider');
+  }
+  return context;
+}
+
+export function useQuery<TData>({ queryKey, queryFn, enabled = true }: QueryOptions<TData>): QueryResult<TData> {
+  const client = useQueryClient();
+  const keyRef = useRef(queryKey);
+  keyRef.current = queryKey;
+  const [data, setData] = useState<TData | undefined>(() => client.getQueryData<TData>(queryKey));
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(enabled && !client.getQueryData<TData>(queryKey));
+
+  const execute = useCallback(async () => {
+    if (!enabled) return data;
+    setIsLoading(true);
+    try {
+      const result = await queryFn();
+      client.setQueryData(keyRef.current, result);
+      setData(result);
+      setError(null);
+      return result;
+    } catch (err) {
+      const errorInstance = err instanceof Error ? err : new Error('Unknown query error');
+      setError(errorInstance);
+      throw errorInstance;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [client, data, enabled, queryFn]);
+
+  useEffect(() => {
+    const unsubscribe = client.subscribe(queryKey, () => {
+      const cached = client.getQueryData<TData>(queryKey);
+      setData(cached);
+    });
+    return unsubscribe;
+  }, [client, queryKey]);
+
+  useEffect(() => {
+    if (enabled && !client.getQueryData<TData>(queryKey)) {
+      void execute();
+    }
+  }, [client, enabled, execute, queryKey]);
+
+  return {
+    data,
+    error,
+    isLoading,
+    refetch: () => execute()
+  };
+}
+
+export function useMutation<TData, TVariables>({ mutationFn, onSuccess, onError }: MutationOptions<TData, TVariables>): MutationResult<TData, TVariables> {
+  const [data, setData] = useState<TData | undefined>(undefined);
+  const [error, setError] = useState<Error | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  const mutate = useCallback(
+    async (variables: TVariables) => {
+      setIsPending(true);
+      setError(null);
+      try {
+        const result = await mutationFn(variables);
+        setData(result);
+        onSuccess?.(result, variables);
+        return result;
+      } catch (err) {
+        const errorInstance = err instanceof Error ? err : new Error('Unknown mutation error');
+        setError(errorInstance);
+        onError?.(errorInstance, variables);
+        throw errorInstance;
+      } finally {
+        setIsPending(false);
+      }
+    },
+    [mutationFn, onError, onSuccess]
+  );
+
+  return {
+    mutate,
+    mutateAsync: mutate,
+    data,
+    error,
+    isPending
+  };
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -21,8 +21,11 @@ export interface UserProfile {
 
 export interface Product {
   id: string;
+  stock_code?: string;
   product_name: string;
   barcode: string;
+  case_barcode?: string | null;
+  unit_barcode?: string | null;
   pack_size: string;
   expected_quantity: number;
   unit_type: 'pallet' | 'case' | 'layer';
@@ -35,6 +38,9 @@ export interface Product {
   available_stock: number;
   created_at: string;
   updated_at: string;
+  units_per_case?: number | null;
+  cases_per_layer?: number | null;
+  layers_per_pallet?: number | null;
 }
 
 export interface StocktakeEntry {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,14 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { QueryClient, QueryClientProvider } from './lib/queryClient.tsx';
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/src/utils/packaging.ts
+++ b/src/utils/packaging.ts
@@ -1,0 +1,35 @@
+export function unitsSingles(units: number | null = 0, cases: number | null = 0, upc?: number) {
+  const singles = typeof units === 'number' ? units : Number(units ?? 0);
+  const caseQty = typeof cases === 'number' ? cases : Number(cases ?? 0);
+  return singles + (upc ? caseQty * upc : 0);
+}
+
+export function unitsPickface(
+  layers: number | null = 0,
+  cases: number | null = 0,
+  upc?: number,
+  cpl?: number
+) {
+  const layerQty = typeof layers === 'number' ? layers : Number(layers ?? 0);
+  const caseQty = typeof cases === 'number' ? cases : Number(cases ?? 0);
+  const layerUnits = upc && cpl ? layerQty * upc * cpl : 0;
+  const caseUnits = upc ? caseQty * upc : 0;
+  return layerUnits + caseUnits;
+}
+
+export function unitsBulk(
+  pallets: number | null = 0,
+  layers: number | null = 0,
+  cases: number | null = 0,
+  upc?: number,
+  cpl?: number,
+  lpp?: number
+) {
+  const palletQty = typeof pallets === 'number' ? pallets : Number(pallets ?? 0);
+  const layerQty = typeof layers === 'number' ? layers : Number(layers ?? 0);
+  const caseQty = typeof cases === 'number' ? cases : Number(cases ?? 0);
+  const palletUnits = upc && cpl && lpp ? palletQty * upc * cpl * lpp : 0;
+  const layerUnits = upc && cpl ? layerQty * upc * cpl : 0;
+  const caseUnits = upc ? caseQty * upc : 0;
+  return palletUnits + layerUnits + caseUnits;
+}


### PR DESCRIPTION
## Summary
- add an event and warehouse context with selectors surfaced in the dashboard
- overhaul the stocktake capture UI with tabbed flows, photo ROI handling, and packaging-aware totals
- introduce shared hooks for submitting counts, variance, recount assignment, and exports with a lightweight query client

## Testing
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e44cc4f14c83299ee354a8c3468e75