### PR TITLE
Add warehouse assignment management for users

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -51,9 +51,10 @@ export default function Dashboard() {
 
     switch (page) {
       case 'stocktake':
+        return true;
       case 'recounts':
       case 'sync':
-        return true;
+        return profile.role !== 'stocktaker';
       case 'bulk':
       case 'variance':
       case 'pallet':
@@ -67,6 +68,10 @@ export default function Dashboard() {
   }
 
   function renderPage() {
+    if (!canAccessPage(currentPage)) {
+      return <StocktakeEntry />;
+    }
+
     switch (currentPage) {
       case 'stocktake':
         return <StocktakeEntry />;
@@ -182,8 +187,12 @@ export default function Dashboard() {
 
             <div className="hidden md:flex items-center gap-6">
               <NavButton page="stocktake" label="Stocktake" icon={<Camera className="w-4 h-4" />} />
-              <NavButton page="recounts" label="Recounts" icon={<ClipboardList className="w-4 h-4" />} />
-              <NavButton page="sync" label="Sync Queue" icon={<Upload className="w-4 h-4" />} />
+              {canAccessPage('recounts') && (
+                <NavButton page="recounts" label="Recounts" icon={<ClipboardList className="w-4 h-4" />} />
+              )}
+              {canAccessPage('sync') && (
+                <NavButton page="sync" label="Sync Queue" icon={<Upload className="w-4 h-4" />} />
+              )}
 
               {canAccessPage('bulk') && (
                 <NavButton page="bulk" label="Bulk Upload" icon={<FileSpreadsheet className="w-4 h-4" />} />
@@ -269,8 +278,12 @@ export default function Dashboard() {
                 </label>
               </div>
               <MobileNavButton page="stocktake" label="Stocktake" icon={<Camera className="w-5 h-5" />} />
-              <MobileNavButton page="recounts" label="Recounts" icon={<ClipboardList className="w-5 h-5" />} />
-              <MobileNavButton page="sync" label="Sync Queue" icon={<Upload className="w-5 h-5" />} />
+              {canAccessPage('recounts') && (
+                <MobileNavButton page="recounts" label="Recounts" icon={<ClipboardList className="w-5 h-5" />} />
+              )}
+              {canAccessPage('sync') && (
+                <MobileNavButton page="sync" label="Sync Queue" icon={<Upload className="w-5 h-5" />} />
+              )}
 
               {canAccessPage('bulk') && (
                 <MobileNavButton page="bulk" label="Bulk Upload" icon={<FileSpreadsheet className="w-5 h-5" />} />

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -3,11 +3,18 @@ import { Users, CreditCard as Edit, Trash2, UserPlus, Shield, Eye, EyeOff } from
 import { supabase, UserProfile } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
 
+interface WarehouseSummary {
+  code: string;
+  name: string;
+}
+
+type ManagedUser = UserProfile & { warehouses?: WarehouseSummary[] };
+
 export default function UserManagement() {
   const { profile } = useAuth();
-  const [users, setUsers] = useState<UserProfile[]>([]);
+  const [users, setUsers] = useState<ManagedUser[]>([]);
   const [loading, setLoading] = useState(true);
-  const [editingUser, setEditingUser] = useState<UserProfile | null>(null);
+  const [editingUser, setEditingUser] = useState<ManagedUser | null>(null);
   const [newRole, setNewRole] = useState<'stocktaker' | 'manager' | 'admin'>('stocktaker');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [newUserEmail, setNewUserEmail] = useState('');
@@ -16,6 +23,72 @@ export default function UserManagement() {
   const [newUserRole, setNewUserRole] = useState<'stocktaker' | 'manager' | 'admin'>('stocktaker');
   const [creating, setCreating] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
+  const [availableWarehouses, setAvailableWarehouses] = useState<WarehouseSummary[]>([]);
+  const [loadingWarehouses, setLoadingWarehouses] = useState(false);
+  const [newUserWarehouses, setNewUserWarehouses] = useState<string[]>([]);
+  const [editingUserWarehouses, setEditingUserWarehouses] = useState<string[]>([]);
+  const [managerAssignedCodes, setManagerAssignedCodes] = useState<string[]>([]);
+
+  const sanitizeWarehouseSelection = useCallback(
+    (selection: string[]) => {
+      const allowedCodes = new Set(
+        availableWarehouses.map((warehouse) => warehouse.code).filter((code): code is string => Boolean(code))
+      );
+
+      if (allowedCodes.size === 0) {
+        return [];
+      }
+
+      const uniqueSelection = new Set(selection.filter((code): code is string => Boolean(code)));
+      return Array.from(uniqueSelection).filter((code) => allowedCodes.has(code));
+    },
+    [availableWarehouses]
+  );
+
+  function normalizeWarehousesFromUser(user: unknown): WarehouseSummary[] {
+    if (!user || typeof user !== 'object') {
+      return [];
+    }
+
+    const rawAssignments = Array.isArray((user as { warehouses?: unknown }).warehouses)
+      ? ((user as { warehouses?: unknown }).warehouses as unknown[])
+      : Array.isArray((user as { user_warehouse_assignments?: unknown }).user_warehouse_assignments)
+        ? ((user as { user_warehouse_assignments?: unknown }).user_warehouse_assignments as unknown[])
+        : [];
+
+    return rawAssignments
+      .map((assignment) => {
+        if (!assignment || typeof assignment !== 'object') {
+          return null;
+        }
+
+        const nestedWarehouse = (assignment as { warehouses?: unknown }).warehouses;
+        const nestedCode =
+          typeof (assignment as { code?: unknown }).code === 'string'
+            ? (assignment as { code?: string }).code
+            : typeof (assignment as { warehouse_code?: unknown }).warehouse_code === 'string'
+              ? (assignment as { warehouse_code?: string }).warehouse_code
+              : typeof (nestedWarehouse as { code?: unknown } | undefined)?.code === 'string'
+                ? (nestedWarehouse as { code: string }).code
+                : undefined;
+
+        if (!nestedCode) {
+          return null;
+        }
+
+        const nestedNameRaw =
+          typeof (assignment as { name?: unknown }).name === 'string'
+            ? (assignment as { name?: string }).name
+            : typeof (nestedWarehouse as { name?: unknown } | undefined)?.name === 'string'
+              ? (nestedWarehouse as { name: string }).name
+              : nestedCode;
+
+        const nestedName = (nestedNameRaw ?? nestedCode).trim() || nestedCode;
+
+        return { code: nestedCode, name: nestedName };
+      })
+      .filter((assignment): assignment is WarehouseSummary => Boolean(assignment?.code));
+  }
 
   const getErrorMessage = useCallback((error: unknown): string => {
     if (error instanceof Error) {
@@ -57,8 +130,12 @@ export default function UserManagement() {
           throw new Error(errorBody.error || 'Failed to load users');
         }
 
-        const data = await response.json();
-        setUsers(data || []);
+        const data = (await response.json()) as Array<ManagedUser | { user_warehouse_assignments?: unknown }> | null;
+        const normalized = (data ?? []).map((user) => ({
+          ...user,
+          warehouses: normalizeWarehousesFromUser(user),
+        }));
+        setUsers(normalized);
       } else {
         const { data, error } = await supabase
           .from('user_profiles')
@@ -67,7 +144,21 @@ export default function UserManagement() {
           .order('created_at', { ascending: false });
 
         if (error) throw error;
-        setUsers(data || []);
+        const { data: assignments, error: assignmentsError } = await supabase
+          .from('user_warehouse_assignments')
+          .select('warehouse_code, warehouses ( code, name )')
+          .eq('user_id', profile?.id);
+
+        if (assignmentsError) throw assignmentsError;
+
+        const assignmentWarehouses = normalizeWarehousesFromUser({ user_warehouse_assignments: assignments });
+
+        setUsers(
+          (data || []).map((user) => ({
+            ...user,
+            warehouses: assignmentWarehouses,
+          }))
+        );
       }
     } catch (error) {
       console.error('Error loading users:', error);
@@ -77,36 +168,103 @@ export default function UserManagement() {
   }, [profile]);
 
   useEffect(() => {
+    let isActive = true;
+
+    async function loadWarehousesForUser() {
+      if (!profile) {
+        return;
+      }
+
+      try {
+        setLoadingWarehouses(true);
+
+        let assignedCodes: string[] = [];
+
+        if (profile.role === 'manager' || profile.role === 'stocktaker') {
+          const { data: assignments, error: assignmentsError } = await supabase
+            .from('user_warehouse_assignments')
+            .select('warehouse_code')
+            .eq('user_id', profile.id);
+
+          if (assignmentsError) throw assignmentsError;
+
+          assignedCodes = (assignments ?? [])
+            .map((assignment) => assignment.warehouse_code as string | null)
+            .filter((code): code is string => Boolean(code));
+
+          if (profile.role === 'manager' && isActive) {
+            setManagerAssignedCodes(assignedCodes);
+          }
+        } else if (isActive) {
+          setManagerAssignedCodes([]);
+        }
+
+        let warehouseQuery = supabase
+          .from('warehouses')
+          .select('code, name')
+          .order('name', { ascending: true });
+
+        if (profile.role === 'manager') {
+          if (assignedCodes.length === 0) {
+            if (isActive) {
+              setAvailableWarehouses([]);
+            }
+            return;
+          }
+
+          warehouseQuery = warehouseQuery.in('code', assignedCodes);
+        }
+
+        const { data: warehouseRows, error: warehousesError } = await warehouseQuery;
+
+        if (warehousesError) throw warehousesError;
+
+        const mapped = (warehouseRows ?? [])
+          .map((row) => ({
+            code: (row.code as string) ?? '',
+            name: ((row.name as string) ?? (row.code as string) ?? '').trim() || 'Unnamed warehouse'
+          }))
+          .filter((warehouse) => warehouse.code);
+
+        if (isActive) {
+          setAvailableWarehouses(mapped);
+        }
+      } catch (error) {
+        console.error('Error loading warehouses:', error);
+        if (isActive) {
+          setAvailableWarehouses([]);
+        }
+      } finally {
+        if (isActive) {
+          setLoadingWarehouses(false);
+        }
+      }
+    }
+
+    loadWarehousesForUser();
+
+    return () => {
+      isActive = false;
+    };
+  }, [profile]);
+
+  useEffect(() => {
     loadUsers();
   }, [loadUsers]);
 
-  async function updateUserRole(userId: string, role: 'stocktaker' | 'manager' | 'admin') {
+  async function updateUserRole(userId: string, role: 'stocktaker' | 'manager' | 'admin', warehouseCodes: string[]) {
+    const sanitizedSelection = sanitizeWarehouseSelection(warehouseCodes);
+
+    if (canAssignWarehouses && role !== 'admin' && sanitizedSelection.length === 0) {
+      alert('Assign at least one warehouse to this user.');
+      return;
+    }
+
     try {
-      const { data: { session } } = await supabase.auth.getSession();
-
-      if (!session) {
-        throw new Error('No active session');
-      }
-
-      const response = await fetch(
-        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/admin-user-management`,
-        {
-          method: 'PUT',
-          headers: {
-            'Authorization': `Bearer ${session.access_token}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ userId, role }),
-        }
-      );
-
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.error || 'Failed to update user role');
-      }
-
+      await syncUserDetails({ userId, role, warehouseCodes: sanitizedSelection });
       await loadUsers();
       setEditingUser(null);
+      setEditingUserWarehouses([]);
     } catch (error: unknown) {
       console.error('Error updating user role:', error);
       alert(getErrorMessage(error));
@@ -149,9 +307,58 @@ export default function UserManagement() {
     }
   }
 
+  async function syncUserDetails({
+    userId,
+    role,
+    warehouseCodes
+  }: {
+    userId: string;
+    role?: 'stocktaker' | 'manager' | 'admin';
+    warehouseCodes?: string[];
+  }) {
+    const { data: { session } } = await supabase.auth.getSession();
+
+    if (!session) {
+      throw new Error('No active session');
+    }
+
+    const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/admin-user-management`, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Bearer ${session.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId,
+        role,
+        warehouseCodes,
+      }),
+    });
+
+    const payload = (await response.json()) as { error?: string } | ManagedUser;
+
+    if (!response.ok) {
+      throw new Error((payload as { error?: string }).error || 'Failed to update user');
+    }
+
+    return payload as ManagedUser;
+  }
+
   async function createUser() {
     if (!newUserEmail || !newUserPassword || !newUserFullName) {
       alert('Please fill in all fields');
+      return;
+    }
+
+    const canAssign = profile?.role === 'admin' || profile?.role === 'manager';
+    const baseSelection =
+      profile?.role === 'manager' && newUserWarehouses.length === 0
+        ? managerAssignedCodes
+        : newUserWarehouses;
+    const warehouseSelection = canAssign ? sanitizeWarehouseSelection(baseSelection) : [];
+
+    if (canAssign && newUserRole !== 'admin' && warehouseSelection.length === 0) {
+      alert('Please select at least one warehouse for the new user.');
       return;
     }
 
@@ -183,12 +390,11 @@ export default function UserManagement() {
       }
 
       if (data.user?.id) {
-        const { error: updateError } = await supabase
-          .from('user_profiles')
-          .update({ role: newUserRole })
-          .eq('id', data.user.id);
-
-        if (updateError) throw updateError;
+        await syncUserDetails({
+          userId: data.user.id,
+          role: newUserRole,
+          warehouseCodes: warehouseSelection
+        });
       }
 
       alert('User created successfully!');
@@ -197,6 +403,11 @@ export default function UserManagement() {
       setNewUserPassword('');
       setNewUserFullName('');
       setNewUserRole('stocktaker');
+      setNewUserWarehouses(
+        profile?.role === 'manager'
+          ? sanitizeWarehouseSelection(managerAssignedCodes)
+          : []
+      );
       await loadUsers();
     } catch (error: unknown) {
       console.error('Error creating user:', error);
@@ -227,6 +438,8 @@ export default function UserManagement() {
   }
 
   const canCreateUsers = profile?.role === 'admin' || profile?.role === 'manager';
+  const canAssignWarehouses = canCreateUsers;
+  const managerCanCreate = profile?.role !== 'manager' || managerAssignedCodes.length > 0;
 
   function getRoleBadgeColor(role: string) {
     switch (role) {
@@ -252,6 +465,13 @@ export default function UserManagement() {
 
   return (
     <div className="max-w-6xl mx-auto">
+      {profile?.role === 'manager' && !loadingWarehouses && managerAssignedCodes.length === 0 && (
+        <div className="bg-yellow-50 border border-yellow-200 text-yellow-800 px-4 py-3 rounded-lg mb-6 text-sm">
+          You must be assigned to at least one warehouse before you can create stocktakers.
+          Please contact an administrator to assign a warehouse to your account.
+        </div>
+      )}
+
       <div className="bg-white rounded-xl shadow-lg p-6">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-2xl font-bold text-gray-800 flex items-center gap-2">
@@ -265,8 +485,20 @@ export default function UserManagement() {
             </div>
             {canCreateUsers && (
               <button
-                onClick={() => setShowCreateModal(true)}
-                className="bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-all flex items-center gap-2"
+                onClick={() => {
+                  setNewUserWarehouses(
+                    profile?.role === 'manager'
+                      ? sanitizeWarehouseSelection(managerAssignedCodes)
+                      : []
+                  );
+                  setShowCreateModal(true);
+                }}
+                disabled={!managerCanCreate || (profile?.role === 'manager' && loadingWarehouses)}
+                className={`bg-blue-600 text-white px-4 py-2 rounded-lg font-medium transition-all flex items-center gap-2 ${
+                  !managerCanCreate || (profile?.role === 'manager' && loadingWarehouses)
+                    ? 'opacity-60 cursor-not-allowed'
+                    : 'hover:bg-blue-700'
+                }`}
               >
                 <UserPlus className="w-5 h-5" />
                 Create User
@@ -281,6 +513,7 @@ export default function UserManagement() {
               <tr className="border-b border-gray-200">
                 <th className="text-left py-3 px-4 font-semibold text-gray-700">Name</th>
                 <th className="text-left py-3 px-4 font-semibold text-gray-700">Role</th>
+                <th className="text-left py-3 px-4 font-semibold text-gray-700">Warehouses</th>
                 <th className="text-left py-3 px-4 font-semibold text-gray-700">Created</th>
                 <th className="text-center py-3 px-4 font-semibold text-gray-700">Actions</th>
               </tr>
@@ -299,6 +532,22 @@ export default function UserManagement() {
                       {user.role.toUpperCase()}
                     </span>
                   </td>
+                  <td className="py-3 px-4">
+                    {user.warehouses && user.warehouses.length > 0 ? (
+                      <div className="flex flex-wrap gap-2">
+                        {user.warehouses.map((warehouse) => (
+                          <span
+                            key={`${user.id}-${warehouse.code}`}
+                            className="px-2 py-1 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700"
+                          >
+                            {warehouse.name}
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-sm text-gray-500">Not assigned</span>
+                    )}
+                  </td>
                   <td className="py-3 px-4 text-sm text-gray-600">
                     {new Date(user.created_at).toLocaleDateString()}
                   </td>
@@ -309,6 +558,11 @@ export default function UserManagement() {
                           onClick={() => {
                             setEditingUser(user);
                             setNewRole(user.role);
+                            setEditingUserWarehouses(
+                              sanitizeWarehouseSelection(
+                                (user.warehouses ?? []).map((warehouse) => warehouse.code)
+                              )
+                            );
                           }}
                           className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-all"
                           title="Edit role"
@@ -374,15 +628,72 @@ export default function UserManagement() {
               </p>
             </div>
 
+            {canAssignWarehouses && (
+              <div className="mb-6">
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Warehouse Access
+                </label>
+                {availableWarehouses.length === 0 ? (
+                  <p className="text-sm text-gray-500">
+                    No warehouses available to assign.
+                  </p>
+                ) : (
+                  <div className="space-y-2 max-h-48 overflow-y-auto pr-1">
+                    {availableWarehouses.map((warehouse) => {
+                      const isChecked = editingUserWarehouses.includes(warehouse.code);
+                      const disabled =
+                        profile?.role === 'manager' && !managerAssignedCodes.includes(warehouse.code);
+
+                      return (
+                        <label
+                          key={`edit-${warehouse.code}`}
+                          className={`flex items-center gap-3 rounded-lg border px-3 py-2 text-sm ${
+                            disabled ? 'bg-gray-100 text-gray-400 border-gray-200' : 'border-gray-200'
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            className="h-4 w-4"
+                            checked={isChecked}
+                            disabled={disabled}
+                            onChange={(event) => {
+                              if (event.target.checked) {
+                                setEditingUserWarehouses((prev) => sanitizeWarehouseSelection([...prev, warehouse.code]));
+                              } else {
+                                setEditingUserWarehouses((prev) => prev.filter((code) => code !== warehouse.code));
+                              }
+                            }}
+                          />
+                          <span className="font-medium text-gray-700">{warehouse.name}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                )}
+                <p className="mt-2 text-xs text-gray-500">
+                  Assign the warehouses this user can access.
+                </p>
+              </div>
+            )}
+
             <div className="flex gap-2">
               <button
-                onClick={() => updateUserRole(editingUser.id, newRole)}
+                onClick={() =>
+                  updateUserRole(
+                    editingUser.id,
+                    newRole,
+                    sanitizeWarehouseSelection(editingUserWarehouses)
+                  )
+                }
                 className="flex-1 bg-blue-600 text-white py-2 rounded-lg font-medium hover:bg-blue-700 transition-all"
               >
                 Update Role
               </button>
               <button
-                onClick={() => setEditingUser(null)}
+                onClick={() => {
+                  setEditingUser(null);
+                  setEditingUserWarehouses([]);
+                }}
                 className="px-6 bg-gray-200 text-gray-700 rounded-lg font-medium hover:bg-gray-300 transition-all"
               >
                 Cancel
@@ -471,6 +782,54 @@ export default function UserManagement() {
                   {profile?.role === 'manager' && 'Managers can create stocktakers only'}
                 </p>
               </div>
+
+              {canAssignWarehouses && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Warehouses *
+                  </label>
+                  {loadingWarehouses ? (
+                    <p className="text-sm text-gray-500">Loading warehouses...</p>
+                  ) : availableWarehouses.length === 0 ? (
+                    <p className="text-sm text-gray-500">No warehouses available.</p>
+                  ) : (
+                    <div className="space-y-2 max-h-48 overflow-y-auto pr-1">
+                      {availableWarehouses.map((warehouse) => {
+                        const disabled =
+                          profile?.role === 'manager' && !managerAssignedCodes.includes(warehouse.code);
+                        const isChecked = newUserWarehouses.includes(warehouse.code);
+
+                        return (
+                          <label
+                            key={`new-${warehouse.code}`}
+                            className={`flex items-center gap-3 rounded-lg border px-3 py-2 text-sm ${
+                              disabled ? 'bg-gray-100 text-gray-400 border-gray-200' : 'border-gray-200'
+                            }`}
+                          >
+                            <input
+                              type="checkbox"
+                              className="h-4 w-4"
+                              checked={isChecked}
+                              disabled={disabled}
+                              onChange={(event) => {
+                                if (event.target.checked) {
+                                  setNewUserWarehouses((prev) => sanitizeWarehouseSelection([...prev, warehouse.code]));
+                                } else {
+                                  setNewUserWarehouses((prev) => prev.filter((code) => code !== warehouse.code));
+                                }
+                              }}
+                            />
+                            <span className="font-medium text-gray-700">{warehouse.name}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  )}
+                  <p className="mt-2 text-xs text-gray-500">
+                    Select the warehouses this user should have access to.
+                  </p>
+                </div>
+              )}
             </div>
 
             <div className="flex gap-2 mt-6">
@@ -488,6 +847,11 @@ export default function UserManagement() {
                   setNewUserPassword('');
                   setNewUserFullName('');
                   setNewUserRole('stocktaker');
+                  setNewUserWarehouses(
+                    profile?.role === 'manager'
+                      ? sanitizeWarehouseSelection(managerAssignedCodes)
+                      : []
+                  );
                 }}
                 disabled={creating}
                 className="px-6 bg-gray-200 text-gray-700 rounded-lg font-medium hover:bg-gray-300 disabled:opacity-50 transition-all"

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -17,6 +17,7 @@ export interface UserProfile {
   full_name: string;
   created_at: string;
   updated_at: string;
+  warehouses?: Array<{ code: string; name: string }>;
 }
 
 export interface Product {

--- a/supabase/functions/admin-user-management/index.ts
+++ b/supabase/functions/admin-user-management/index.ts
@@ -6,6 +6,84 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Client-Info, Apikey',
 };
 
+interface WarehouseSummary {
+  code: string;
+  name: string;
+}
+
+function formatWarehouses(assignments: unknown): WarehouseSummary[] {
+  if (!Array.isArray(assignments)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const result: WarehouseSummary[] = [];
+
+  for (const assignment of assignments) {
+    if (!assignment || typeof assignment !== 'object') {
+      continue;
+    }
+
+    const nestedWarehouse = (assignment as { warehouses?: unknown }).warehouses as
+      | { code?: string; name?: string }
+      | undefined;
+
+    const warehouseCode =
+      typeof (assignment as { warehouse_code?: unknown }).warehouse_code === 'string'
+        ? (assignment as { warehouse_code?: string }).warehouse_code!
+        : typeof nestedWarehouse?.code === 'string'
+          ? nestedWarehouse.code
+          : typeof (assignment as { code?: unknown }).code === 'string'
+            ? (assignment as { code?: string }).code!
+            : undefined;
+
+    if (!warehouseCode || seen.has(warehouseCode)) {
+      continue;
+    }
+
+    const warehouseName =
+      typeof nestedWarehouse?.name === 'string'
+        ? nestedWarehouse.name
+        : typeof (assignment as { name?: unknown }).name === 'string'
+          ? (assignment as { name?: string }).name!
+          : warehouseCode;
+
+    seen.add(warehouseCode);
+    result.push({ code: warehouseCode, name: warehouseName.trim() || warehouseCode });
+  }
+
+  return result;
+}
+
+function formatUserRow(row: Record<string, unknown>) {
+  return {
+    id: row.id,
+    full_name: row.full_name,
+    role: row.role,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    warehouses: formatWarehouses((row as { user_warehouse_assignments?: unknown }).user_warehouse_assignments),
+  };
+}
+
+async function getManagerWarehouseCodes(
+  supabase: ReturnType<typeof createClient>,
+  managerId: string,
+): Promise<string[]> {
+  const { data, error } = await supabase
+    .from('user_warehouse_assignments')
+    .select('warehouse_code')
+    .eq('user_id', managerId);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? [])
+    .map((assignment) => assignment?.warehouse_code)
+    .filter((code): code is string => typeof code === 'string' && code.trim().length > 0);
+}
+
 Deno.serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, {
@@ -49,14 +127,74 @@ Deno.serve(async (req: Request) => {
     const path = url.pathname.split('/').pop();
 
     if (req.method === 'GET' && path === 'admin-user-management') {
-      const { data: users, error } = await supabase
+      if (profile.role === 'admin') {
+        const { data, error } = await supabase
+          .from('user_profiles')
+          .select(`
+            id,
+            full_name,
+            role,
+            created_at,
+            updated_at,
+            user_warehouse_assignments (
+              warehouse_code,
+              warehouses ( code, name )
+            )
+          `)
+          .order('created_at', { ascending: false });
+
+        if (error) throw error;
+
+        const formatted = (data ?? []).map((row) => formatUserRow(row as Record<string, unknown>));
+
+        return new Response(JSON.stringify(formatted), {
+          headers: {
+            ...corsHeaders,
+            'Content-Type': 'application/json',
+          },
+        });
+      }
+
+      const managerWarehouseCodes = await getManagerWarehouseCodes(supabase, user.id);
+      const userIds = new Set<string>([user.id]);
+
+      if (managerWarehouseCodes.length > 0) {
+        const { data: assignmentRows, error: assignmentError } = await supabase
+          .from('user_warehouse_assignments')
+          .select('user_id')
+          .in('warehouse_code', managerWarehouseCodes);
+
+        if (assignmentError) throw assignmentError;
+
+        for (const assignment of assignmentRows ?? []) {
+          const assignedUserId = assignment?.user_id as string | undefined;
+          if (assignedUserId) {
+            userIds.add(assignedUserId);
+          }
+        }
+      }
+
+      const { data: managerUsers, error: managerError } = await supabase
         .from('user_profiles')
-        .select('*')
-        .order('created_at', { ascending: false });
+        .select(`
+          id,
+          full_name,
+          role,
+          created_at,
+          updated_at,
+          user_warehouse_assignments (
+            warehouse_code,
+            warehouses ( code, name )
+          )
+        `)
+        .in('id', Array.from(userIds));
 
-      if (error) throw error;
+      if (managerError) throw managerError;
 
-      return new Response(JSON.stringify(users), {
+      const filtered = (managerUsers ?? []).filter((row) => row.id === user.id || row.role === 'stocktaker');
+      const formatted = filtered.map((row) => formatUserRow(row as Record<string, unknown>));
+
+      return new Response(JSON.stringify(formatted), {
         headers: {
           ...corsHeaders,
           'Content-Type': 'application/json',
@@ -65,22 +203,101 @@ Deno.serve(async (req: Request) => {
     }
 
     if (req.method === 'PUT') {
-      const { userId, role } = await req.json();
+      const { userId, role, warehouseCodes } = await req.json();
 
-      if (!userId || !role) {
-        throw new Error('Missing userId or role');
+      if (!userId) {
+        throw new Error('Missing userId');
       }
 
-      const { data, error } = await supabase
+      const { data: targetUser, error: targetError } = await supabase
         .from('user_profiles')
-        .update({ role })
+        .select('role')
         .eq('id', userId)
-        .select()
         .single();
 
-      if (error) throw error;
+      if (targetError || !targetUser) {
+        throw new Error('User not found');
+      }
 
-      return new Response(JSON.stringify(data), {
+      if (profile.role === 'manager') {
+        if (targetUser.role !== 'stocktaker') {
+          throw new Error('Managers can only manage stocktakers');
+        }
+
+        if (role && role !== 'stocktaker') {
+          throw new Error('Managers can only assign stocktaker role');
+        }
+      }
+
+      if (role && role !== targetUser.role) {
+        const { error: updateRoleError } = await supabase
+          .from('user_profiles')
+          .update({ role })
+          .eq('id', userId);
+
+        if (updateRoleError) throw updateRoleError;
+      }
+
+      const nextRole = (role ?? targetUser.role) as 'stocktaker' | 'manager' | 'admin';
+
+      if (Array.isArray(warehouseCodes)) {
+        const sanitizedCodes = Array.from(
+          new Set(
+            warehouseCodes.filter((code: unknown): code is string => typeof code === 'string' && code.trim().length > 0)
+          )
+        );
+
+        let finalCodes = sanitizedCodes;
+
+        if (profile.role === 'manager') {
+          const allowedCodes = new Set(await getManagerWarehouseCodes(supabase, user.id));
+          finalCodes = sanitizedCodes.filter((code) => allowedCodes.has(code));
+
+          if (finalCodes.length === 0) {
+            throw new Error('Managers must assign at least one of their warehouses');
+          }
+        }
+
+        if (nextRole !== 'admin' && finalCodes.length === 0) {
+          throw new Error('At least one warehouse is required for this role');
+        }
+
+        const { error: deleteAssignmentsError } = await supabase
+          .from('user_warehouse_assignments')
+          .delete()
+          .eq('user_id', userId);
+
+        if (deleteAssignmentsError) throw deleteAssignmentsError;
+
+        if (finalCodes.length > 0) {
+          const rows = finalCodes.map((code) => ({ user_id: userId, warehouse_code: code }));
+          const { error: upsertError } = await supabase
+            .from('user_warehouse_assignments')
+            .upsert(rows, { onConflict: 'user_id,warehouse_code' });
+
+          if (upsertError) throw upsertError;
+        }
+      }
+
+      const { data: refreshedUser, error: refreshedError } = await supabase
+        .from('user_profiles')
+        .select(`
+          id,
+          full_name,
+          role,
+          created_at,
+          updated_at,
+          user_warehouse_assignments (
+            warehouse_code,
+            warehouses ( code, name )
+          )
+        `)
+        .eq('id', userId)
+        .single();
+
+      if (refreshedError || !refreshedUser) throw refreshedError;
+
+      return new Response(JSON.stringify(formatUserRow(refreshedUser as Record<string, unknown>)), {
         headers: {
           ...corsHeaders,
           'Content-Type': 'application/json',

--- a/supabase/migrations/20251005190000_add_warehouses_and_assignments.sql
+++ b/supabase/migrations/20251005190000_add_warehouses_and_assignments.sql
@@ -1,0 +1,96 @@
+-- Create warehouses table if it doesn't exist
+CREATE TABLE IF NOT EXISTS warehouses (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL UNIQUE,
+  name text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Ensure trigger exists to keep updated_at fresh
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+DROP TRIGGER IF EXISTS warehouses_updated_at ON warehouses;
+CREATE TRIGGER warehouses_updated_at
+BEFORE UPDATE ON warehouses
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+
+-- Allow anyone with a session to read warehouses
+ALTER TABLE warehouses ENABLE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'warehouses'
+      AND policyname = 'Allow authenticated read warehouses'
+  ) THEN
+    CREATE POLICY "Allow authenticated read warehouses"
+      ON warehouses FOR SELECT
+      TO authenticated
+      USING (true);
+  END IF;
+END$$;
+
+-- Create user_warehouse_assignments table
+CREATE TABLE IF NOT EXISTS user_warehouse_assignments (
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  warehouse_code text NOT NULL REFERENCES warehouses(code) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, warehouse_code)
+);
+
+ALTER TABLE user_warehouse_assignments ENABLE ROW LEVEL SECURITY;
+
+-- Policies for user_warehouse_assignments
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_warehouse_assignments'
+      AND policyname = 'Allow users to view their own warehouse assignments'
+  ) THEN
+    CREATE POLICY "Allow users to view their own warehouse assignments"
+      ON user_warehouse_assignments FOR SELECT
+      TO authenticated
+      USING (user_id = auth.uid());
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_warehouse_assignments'
+      AND policyname = 'Admins can manage all warehouse assignments'
+  ) THEN
+    CREATE POLICY "Admins can manage all warehouse assignments"
+      ON user_warehouse_assignments FOR ALL
+      TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM user_profiles
+          WHERE user_profiles.id = auth.uid()
+            AND user_profiles.role = 'admin'
+        )
+      )
+      WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM user_profiles
+          WHERE user_profiles.id = auth.uid()
+            AND user_profiles.role = 'admin'
+        )
+      );
+  END IF;
+END$$;


### PR DESCRIPTION
## Summary
- restrict dashboard navigation so stocktakers only access the stocktake workflow
- add warehouse-aware user management UI for admins and managers, including assignment pickers and validation
- expand the admin user management edge function and database schema to store warehouse assignments and enforce role rules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e452a86b488329b86d339bae32b234