### PR TITLE
Default admins to admin dashboard on login

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import {
   Camera,
   ClipboardList,
@@ -48,6 +48,14 @@ export default function Dashboard() {
     warehouseCode,
     setWarehouseCode
   } = useEventWarehouse();
+
+  useEffect(() => {
+    if (profile?.role === 'admin') {
+      setCurrentPage((previousPage) =>
+        previousPage === 'admin' ? previousPage : 'admin'
+      );
+    }
+  }, [profile?.role]);
 
   async function handleSignOut() {
     try {


### PR DESCRIPTION
## Summary
- ensure the dashboard defaults admin users to the admin dashboard view
- add a role-aware effect so admin users immediately land on the admin page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5611287408329989049398f9271ef