### PR TITLE
feat: add admin dashboard view toggles and dark mode support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { AuthProvider } from './contexts/AuthContext';
 import { useAuth } from './hooks/useAuth';
 import { EventWarehouseProvider } from './contexts/EventWarehouseContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 import Login from './components/Login';
 import Register from './components/Register';
 import Dashboard from './components/Dashboard';
@@ -34,11 +35,13 @@ function AppContent() {
 
 function App() {
   return (
-    <AuthProvider>
-      <EventWarehouseProvider>
-        <AppContent />
-      </EventWarehouseProvider>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <EventWarehouseProvider>
+          <AppContent />
+        </EventWarehouseProvider>
+      </AuthProvider>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -7,8 +7,10 @@ import {
   FileText,
   LogOut,
   Menu,
+  Moon,
   Package,
   Settings,
+  Sun,
   Upload,
   Users,
   X
@@ -24,6 +26,7 @@ import PalletConfiguration from './PalletConfiguration';
 import Recounts from './Recounts';
 import ExportCounts from './ExportCounts';
 import AdminDashboard from './AdminDashboard';
+import { useTheme } from '../hooks/useTheme';
 
 type Page =
   | 'stocktake'
@@ -36,10 +39,14 @@ type Page =
   | 'export'
   | 'admin';
 
+type RoleView = 'stocktaker' | 'manager' | 'admin';
+
 export default function Dashboard() {
   const { profile, signOut } = useAuth();
+  const { isDarkMode, toggleTheme } = useTheme();
   const [currentPage, setCurrentPage] = useState<Page>('stocktake');
   const [menuOpen, setMenuOpen] = useState(false);
+  const [adminView, setAdminView] = useState<RoleView>('admin');
   const {
     events,
     eventId,
@@ -49,13 +56,32 @@ export default function Dashboard() {
     setWarehouseCode
   } = useEventWarehouse();
 
+  const activeRole: RoleView =
+    profile?.role === 'admin' ? adminView : (profile?.role ?? 'stocktaker');
+
   useEffect(() => {
     if (profile?.role === 'admin') {
-      setCurrentPage((previousPage) =>
-        previousPage === 'admin' ? previousPage : 'admin'
-      );
+      setAdminView('admin');
     }
   }, [profile?.role]);
+
+  useEffect(() => {
+    if (profile?.role !== 'admin') {
+      return;
+    }
+
+    setCurrentPage((previousPage) => {
+      const defaultPage: Record<RoleView, Page> = {
+        stocktaker: 'stocktake',
+        manager: 'stocktake',
+        admin: 'admin'
+      };
+
+      return canAccessPage(previousPage, activeRole)
+        ? previousPage
+        : defaultPage[activeRole];
+    });
+  }, [activeRole, profile?.role]);
 
   async function handleSignOut() {
     try {
@@ -65,31 +91,31 @@ export default function Dashboard() {
     }
   }
 
-  function canAccessPage(page: Page): boolean {
-    if (!profile) return false;
+  function canAccessPage(page: Page, role: RoleView): boolean {
+    if (!role) return false;
 
     switch (page) {
       case 'stocktake':
         return true;
       case 'recounts':
       case 'sync':
-        return profile.role !== 'stocktaker';
+        return role !== 'stocktaker';
       case 'bulk':
       case 'variance':
       case 'pallet':
       case 'export':
-        return ['manager', 'admin'].includes(profile.role);
+        return ['manager', 'admin'].includes(role);
       case 'users':
-        return profile.role === 'admin';
+        return role === 'admin';
       case 'admin':
-        return profile.role === 'admin';
+        return role === 'admin';
       default:
         return false;
     }
   }
 
   function renderPage() {
-    if (!canAccessPage(currentPage)) {
+    if (!canAccessPage(currentPage, activeRole)) {
       return <StocktakeEntry />;
     }
 
@@ -130,8 +156,10 @@ export default function Dashboard() {
     return (
       <button
         onClick={() => setCurrentPage(page)}
-        className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all ${
-          isActive ? 'bg-blue-600 text-white' : 'text-gray-700 hover:bg-gray-100'
+        className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${
+          isActive
+            ? 'bg-blue-600 text-white shadow-sm dark:bg-blue-500'
+            : 'text-gray-700 hover:bg-gray-100 dark:text-slate-200 dark:hover:bg-slate-800'
         }`}
       >
         {icon}
@@ -156,8 +184,10 @@ export default function Dashboard() {
           setCurrentPage(page);
           setMenuOpen(false);
         }}
-        className={`w-full flex items-center gap-2 px-4 py-3 rounded-lg font-medium transition-all ${
-          isActive ? 'bg-blue-600 text-white' : 'text-gray-700 hover:bg-gray-100'
+        className={`w-full flex items-center gap-2 px-4 py-3 rounded-lg font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${
+          isActive
+            ? 'bg-blue-600 text-white shadow-sm dark:bg-blue-500'
+            : 'text-gray-700 hover:bg-gray-100 dark:text-slate-200 dark:hover:bg-slate-800'
         }`}
       >
         {icon}
@@ -167,20 +197,20 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <nav className="bg-white border-b border-gray-200 sticky top-0 z-40 shadow-sm">
+    <div className="min-h-screen bg-gray-50 text-gray-900 transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100">
+      <nav className="bg-white border-b border-gray-200 sticky top-0 z-40 shadow-sm transition-colors duration-300 dark:bg-slate-900 dark:border-slate-800">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">
               <div className="flex-shrink-0 flex items-center">
                 <Camera className="w-8 h-8 text-blue-600" />
-                <h1 className="ml-2 text-xl font-bold text-gray-800">Smart Stocktake</h1>
+                <h1 className="ml-2 text-xl font-bold text-gray-800 dark:text-white">Smart Stocktake</h1>
               </div>
               <div className="hidden md:flex items-center gap-3 ml-6">
                 <select
                   value={eventId ?? ''}
                   onChange={(event) => setEventId(event.target.value)}
-                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/50"
                 >
                   <option value="" disabled>
                     Select event
@@ -194,7 +224,7 @@ export default function Dashboard() {
                 <select
                   value={warehouseCode ?? ''}
                   onChange={(event) => setWarehouseCode(event.target.value)}
-                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/50"
                 >
                   <option value="" disabled>
                     Select warehouse
@@ -210,45 +240,81 @@ export default function Dashboard() {
 
             <div className="hidden md:flex items-center gap-6">
               <NavButton page="stocktake" label="Stocktake" icon={<Camera className="w-4 h-4" />} />
-              {canAccessPage('recounts') && (
+              {canAccessPage('recounts', activeRole) && (
                 <NavButton page="recounts" label="Recounts" icon={<ClipboardList className="w-4 h-4" />} />
               )}
-              {canAccessPage('sync') && (
+              {canAccessPage('sync', activeRole) && (
                 <NavButton page="sync" label="Sync Queue" icon={<Upload className="w-4 h-4" />} />
               )}
 
-              {canAccessPage('bulk') && (
+              {canAccessPage('bulk', activeRole) && (
                 <NavButton page="bulk" label="Bulk Upload" icon={<FileSpreadsheet className="w-4 h-4" />} />
               )}
 
-              {canAccessPage('pallet') && (
+              {canAccessPage('pallet', activeRole) && (
                 <NavButton page="pallet" label="Pallet Config" icon={<Package className="w-4 h-4" />} />
               )}
 
-              {canAccessPage('variance') && (
+              {canAccessPage('variance', activeRole) && (
                 <NavButton page="variance" label="Variance" icon={<FileText className="w-4 h-4" />} />
               )}
 
-              {canAccessPage('users') && (
+              {canAccessPage('users', activeRole) && (
                 <NavButton page="users" label="Users" icon={<Users className="w-4 h-4" />} />
               )}
 
-              {canAccessPage('export') && (
+              {canAccessPage('export', activeRole) && (
                 <NavButton page="export" label="Export" icon={<Download className="w-4 h-4" />} />
               )}
 
-              {canAccessPage('admin') && (
+              {canAccessPage('admin', activeRole) && (
                 <NavButton page="admin" label="Admin" icon={<Settings className="w-4 h-4" />} />
               )}
 
-              <div className="flex items-center gap-3 ml-4 pl-4 border-l border-gray-200">
+              {profile?.role === 'admin' && (
+                <div className="flex items-center gap-2 ml-2 pl-4 border-l border-gray-200 dark:border-slate-800">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">
+                    View as
+                  </span>
+                  <div className="flex rounded-lg border border-gray-200 bg-gray-100 dark:border-slate-700 dark:bg-slate-800">
+                    {(['stocktaker', 'manager', 'admin'] as RoleView[]).map((roleOption) => {
+                      const isSelected = adminView === roleOption;
+                      return (
+                        <button
+                          key={roleOption}
+                          onClick={() => setAdminView(roleOption)}
+                          className={`px-3 py-1 text-sm font-medium capitalize transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${
+                            isSelected
+                              ? 'bg-blue-600 text-white shadow-sm dark:bg-blue-500'
+                              : 'text-gray-700 hover:bg-white dark:text-slate-200 dark:hover:bg-slate-700'
+                          }`}
+                          type="button"
+                        >
+                          {roleOption}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              <button
+                onClick={toggleTheme}
+                className="p-2 rounded-lg text-gray-600 transition-colors hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-900"
+                title={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+                type="button"
+              >
+                {isDarkMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+              </button>
+
+              <div className="flex items-center gap-3 ml-4 pl-4 border-l border-gray-200 dark:border-slate-800">
                 <div className="text-right">
-                  <p className="text-sm font-medium text-gray-800">{profile?.full_name}</p>
-                  <p className="text-xs text-gray-500 capitalize">{profile?.role}</p>
+                  <p className="text-sm font-medium text-gray-800 dark:text-white">{profile?.full_name}</p>
+                  <p className="text-xs text-gray-500 capitalize dark:text-slate-400">{profile?.role}</p>
                 </div>
                 <button
                   onClick={handleSignOut}
-                  className="p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-all"
+                  className="p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-900"
                   title="Sign out"
                 >
                   <LogOut className="w-5 h-5" />
@@ -258,7 +324,8 @@ export default function Dashboard() {
 
             <button
               onClick={() => setMenuOpen(!menuOpen)}
-              className="md:hidden p-2 text-gray-600 hover:bg-gray-100 rounded-lg"
+              className="md:hidden p-2 text-gray-600 hover:bg-gray-100 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-900"
+              type="button"
             >
               {menuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
             </button>
@@ -266,15 +333,15 @@ export default function Dashboard() {
         </div>
 
         {menuOpen && (
-          <div className="md:hidden border-t border-gray-200 bg-white">
+          <div className="md:hidden border-t border-gray-200 bg-white transition-colors dark:border-slate-800 dark:bg-slate-900">
             <div className="px-4 py-3 space-y-2">
               <div className="space-y-2">
-                <label className="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <label className="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">
                   Event
                   <select
                     value={eventId ?? ''}
                     onChange={(event) => setEventId(event.target.value)}
-                    className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/50"
                   >
                     <option value="" disabled>
                       Select event
@@ -286,12 +353,12 @@ export default function Dashboard() {
                     ))}
                   </select>
                 </label>
-                <label className="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <label className="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">
                   Warehouse
                   <select
                     value={warehouseCode ?? ''}
                     onChange={(event) => setWarehouseCode(event.target.value)}
-                    className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/50"
                   >
                     <option value="" disabled>
                       Select warehouse
@@ -304,49 +371,84 @@ export default function Dashboard() {
                   </select>
                 </label>
               </div>
+              {profile?.role === 'admin' && (
+                <div className="pt-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">
+                    View as
+                  </p>
+                  <div className="mt-2 flex gap-2">
+                    {(['stocktaker', 'manager', 'admin'] as RoleView[]).map((roleOption) => {
+                      const isSelected = adminView === roleOption;
+                      return (
+                        <button
+                          key={roleOption}
+                          onClick={() => setAdminView(roleOption)}
+                          className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium capitalize transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${
+                            isSelected
+                              ? 'border-blue-600 bg-blue-600 text-white dark:border-blue-500 dark:bg-blue-500'
+                              : 'border-gray-200 text-gray-700 hover:bg-gray-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800'
+                          }`}
+                          type="button"
+                        >
+                          {roleOption}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
               <MobileNavButton page="stocktake" label="Stocktake" icon={<Camera className="w-5 h-5" />} />
-              {canAccessPage('recounts') && (
+              {canAccessPage('recounts', activeRole) && (
                 <MobileNavButton page="recounts" label="Recounts" icon={<ClipboardList className="w-5 h-5" />} />
               )}
-              {canAccessPage('sync') && (
+              {canAccessPage('sync', activeRole) && (
                 <MobileNavButton page="sync" label="Sync Queue" icon={<Upload className="w-5 h-5" />} />
               )}
 
-              {canAccessPage('bulk') && (
+              {canAccessPage('bulk', activeRole) && (
                 <MobileNavButton page="bulk" label="Bulk Upload" icon={<FileSpreadsheet className="w-5 h-5" />} />
               )}
 
-              {canAccessPage('pallet') && (
+              {canAccessPage('pallet', activeRole) && (
                 <MobileNavButton page="pallet" label="Pallet Config" icon={<Package className="w-5 h-5" />} />
               )}
 
-              {canAccessPage('variance') && (
+              {canAccessPage('variance', activeRole) && (
                 <MobileNavButton page="variance" label="Variance" icon={<FileText className="w-5 h-5" />} />
               )}
 
-              {canAccessPage('users') && (
+              {canAccessPage('users', activeRole) && (
                 <MobileNavButton page="users" label="Users" icon={<Users className="w-5 h-5" />} />
               )}
 
-              {canAccessPage('export') && (
+              {canAccessPage('export', activeRole) && (
                 <MobileNavButton page="export" label="Export" icon={<Download className="w-5 h-5" />} />
               )}
 
-              {canAccessPage('admin') && (
+              {canAccessPage('admin', activeRole) && (
                 <MobileNavButton page="admin" label="Admin" icon={<Settings className="w-5 h-5" />} />
               )}
 
               <div className="pt-3 border-t border-gray-200">
                 <div className="px-4 py-2">
-                  <p className="text-sm font-medium text-gray-800">{profile?.full_name}</p>
-                  <p className="text-xs text-gray-500 capitalize">{profile?.role}</p>
+                  <p className="text-sm font-medium text-gray-800 dark:text-white">{profile?.full_name}</p>
+                  <p className="text-xs text-gray-500 capitalize dark:text-slate-400">{profile?.role}</p>
                 </div>
                 <button
                   onClick={handleSignOut}
-                  className="w-full flex items-center gap-2 px-4 py-3 rounded-lg font-medium text-red-600 hover:bg-red-50 transition-all"
+                  className="w-full flex items-center gap-2 px-4 py-3 rounded-lg font-medium text-red-600 hover:bg-red-50 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:hover:bg-red-500/10 dark:focus-visible:ring-offset-slate-900"
+                  type="button"
                 >
                   <LogOut className="w-5 h-5" />
                   Sign Out
+                </button>
+                <button
+                  onClick={toggleTheme}
+                  className="mt-2 w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg font-medium text-gray-700 transition-colors hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-900"
+                  type="button"
+                >
+                  {isDarkMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+                  {isDarkMode ? 'Light mode' : 'Dark mode'}
                 </button>
               </div>
             </div>
@@ -354,7 +456,9 @@ export default function Dashboard() {
         )}
       </nav>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">{renderPage()}</main>
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 transition-colors duration-300">
+        {renderPage()}
+      </main>
     </div>
   );
 }

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
+import { LogIn, Eye, EyeOff, Moon, Sun } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
-import { LogIn, Eye, EyeOff } from 'lucide-react';
+import { useTheme } from '../hooks/useTheme';
 
 interface LoginProps {
   onToggleRegister: () => void;
@@ -8,6 +9,7 @@ interface LoginProps {
 
 export default function Login({ onToggleRegister }: LoginProps) {
   const { signIn } = useAuth();
+  const { isDarkMode, toggleTheme } = useTheme();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -29,26 +31,34 @@ export default function Login({ onToggleRegister }: LoginProps) {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 to-slate-800 p-4">
-      <div className="bg-white rounded-xl shadow-2xl p-8 w-full max-w-md">
+    <div className="relative min-h-screen flex items-center justify-center bg-slate-100 p-4 transition-colors duration-300 dark:bg-slate-950">
+      <button
+        type="button"
+        onClick={toggleTheme}
+        className="absolute top-6 right-6 flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-gray-700 shadow-lg backdrop-blur transition-colors hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-100 dark:bg-slate-900/80 dark:text-slate-200 dark:hover:bg-slate-900 dark:focus-visible:ring-offset-slate-950"
+      >
+        {isDarkMode ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+        {isDarkMode ? 'Light mode' : 'Dark mode'}
+      </button>
+      <div className="w-full max-w-md rounded-xl bg-white p-8 shadow-2xl transition-colors duration-300 dark:bg-slate-900 dark:shadow-slate-900/60">
         <div className="flex items-center justify-center mb-8">
-          <div className="bg-blue-600 p-3 rounded-full">
-            <LogIn className="w-8 h-8 text-white" />
+          <div className="rounded-full bg-blue-600 p-3">
+            <LogIn className="h-8 w-8 text-white" />
           </div>
         </div>
 
-        <h2 className="text-3xl font-bold text-center text-gray-800 mb-2">Welcome Back</h2>
-        <p className="text-center text-gray-600 mb-8">Sign in to your stocktake account</p>
+        <h2 className="mb-2 text-center text-3xl font-bold text-gray-800 dark:text-white">Welcome Back</h2>
+        <p className="mb-8 text-center text-gray-600 dark:text-slate-300">Sign in to your stocktake account</p>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+            <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
               {error}
             </div>
           )}
 
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="email" className="mb-2 block text-sm font-medium text-gray-700 dark:text-slate-200">
               Email Address
             </label>
             <input
@@ -57,13 +67,13 @@ export default function Login({ onToggleRegister }: LoginProps) {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+              className="w-full rounded-lg border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
               placeholder="you@company.com"
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="password" className="mb-2 block text-sm font-medium text-gray-700 dark:text-slate-200">
               Password
             </label>
             <div className="relative">
@@ -73,19 +83,19 @@ export default function Login({ onToggleRegister }: LoginProps) {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
-                className="w-full px-4 py-3 pr-12 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                className="w-full rounded-lg border border-gray-300 px-4 py-3 pr-12 transition-all focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-500/40"
                 placeholder="Enter your password"
               />
               <button
                 type="button"
                 onClick={() => setShowPassword(!showPassword)}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition-colors"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 transition-colors hover:text-gray-700 dark:text-slate-400 dark:hover:text-slate-200"
                 tabIndex={-1}
               >
                 {showPassword ? (
-                  <EyeOff className="w-5 h-5" />
+                  <EyeOff className="h-5 w-5" />
                 ) : (
-                  <Eye className="w-5 h-5" />
+                  <Eye className="h-5 w-5" />
                 )}
               </button>
             </div>
@@ -94,7 +104,7 @@ export default function Login({ onToggleRegister }: LoginProps) {
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-blue-600 text-white py-3 rounded-lg font-medium hover:bg-blue-700 focus:ring-4 focus:ring-blue-200 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            className="w-full rounded-lg bg-blue-600 py-3 font-medium text-white transition-all hover:bg-blue-700 focus:outline-none focus-visible:ring-4 focus-visible:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus-visible:ring-blue-500/40"
           >
             {loading ? 'Signing in...' : 'Sign In'}
           </button>
@@ -103,7 +113,7 @@ export default function Login({ onToggleRegister }: LoginProps) {
         <div className="mt-6 text-center">
           <button
             onClick={onToggleRegister}
-            className="text-blue-600 hover:text-blue-700 font-medium text-sm transition-colors"
+            className="text-sm font-medium text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
           >
             Don't have an account? Register
           </button>

--- a/src/components/Register.tsx
+++ b/src/components/Register.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
+import { UserPlus, Eye, EyeOff, Moon, Sun } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
-import { UserPlus, Eye, EyeOff } from 'lucide-react';
+import { useTheme } from '../hooks/useTheme';
 
 interface RegisterProps {
   onToggleLogin: () => void;
@@ -8,6 +9,7 @@ interface RegisterProps {
 
 export default function Register({ onToggleLogin }: RegisterProps) {
   const { signUp } = useAuth();
+  const { isDarkMode, toggleTheme } = useTheme();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [fullName, setFullName] = useState('');
@@ -36,32 +38,40 @@ export default function Register({ onToggleLogin }: RegisterProps) {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 to-slate-800 p-4">
-      <div className="bg-white rounded-xl shadow-2xl p-8 w-full max-w-md">
+    <div className="relative min-h-screen flex items-center justify-center bg-slate-100 p-4 transition-colors duration-300 dark:bg-slate-950">
+      <button
+        type="button"
+        onClick={toggleTheme}
+        className="absolute top-6 right-6 flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-gray-700 shadow-lg backdrop-blur transition-colors hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-100 dark:bg-slate-900/80 dark:text-slate-200 dark:hover:bg-slate-900 dark:focus-visible:ring-offset-slate-950"
+      >
+        {isDarkMode ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+        {isDarkMode ? 'Light mode' : 'Dark mode'}
+      </button>
+      <div className="w-full max-w-md rounded-xl bg-white p-8 shadow-2xl transition-colors duration-300 dark:bg-slate-900 dark:shadow-slate-900/60">
         <div className="flex items-center justify-center mb-8">
-          <div className="bg-green-600 p-3 rounded-full">
-            <UserPlus className="w-8 h-8 text-white" />
+          <div className="rounded-full bg-green-600 p-3">
+            <UserPlus className="h-8 w-8 text-white" />
           </div>
         </div>
 
-        <h2 className="text-3xl font-bold text-center text-gray-800 mb-2">Create Account</h2>
-        <p className="text-center text-gray-600 mb-8">Join the stocktake system</p>
+        <h2 className="mb-2 text-center text-3xl font-bold text-gray-800 dark:text-white">Create Account</h2>
+        <p className="mb-8 text-center text-gray-600 dark:text-slate-300">Join the stocktake system</p>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+            <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
               {error}
             </div>
           )}
 
           {success && (
-            <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg text-sm">
+            <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700 dark:border-green-500/40 dark:bg-green-500/10 dark:text-green-200">
               Account created successfully! Redirecting to login...
             </div>
           )}
 
           <div>
-            <label htmlFor="fullName" className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="fullName" className="mb-2 block text-sm font-medium text-gray-700 dark:text-slate-200">
               Full Name
             </label>
             <input
@@ -70,13 +80,13 @@ export default function Register({ onToggleLogin }: RegisterProps) {
               value={fullName}
               onChange={(e) => setFullName(e.target.value)}
               required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent transition-all"
+              className="w-full rounded-lg border border-gray-300 px-4 py-3 transition-all focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-green-400 dark:focus:ring-green-500/40"
               placeholder="John Doe"
             />
           </div>
 
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="email" className="mb-2 block text-sm font-medium text-gray-700 dark:text-slate-200">
               Email Address
             </label>
             <input
@@ -85,13 +95,13 @@ export default function Register({ onToggleLogin }: RegisterProps) {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent transition-all"
+              className="w-full rounded-lg border border-gray-300 px-4 py-3 transition-all focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-green-400 dark:focus:ring-green-500/40"
               placeholder="you@company.com"
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="password" className="mb-2 block text-sm font-medium text-gray-700 dark:text-slate-200">
               Password
             </label>
             <div className="relative">
@@ -102,19 +112,19 @@ export default function Register({ onToggleLogin }: RegisterProps) {
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 minLength={6}
-                className="w-full px-4 py-3 pr-12 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent transition-all"
+                className="w-full rounded-lg border border-gray-300 px-4 py-3 pr-12 transition-all focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-green-400 dark:focus:ring-green-500/40"
                 placeholder="Minimum 6 characters"
               />
               <button
                 type="button"
                 onClick={() => setShowPassword(!showPassword)}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition-colors"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 transition-colors hover:text-gray-700 dark:text-slate-400 dark:hover:text-slate-200"
                 tabIndex={-1}
               >
                 {showPassword ? (
-                  <EyeOff className="w-5 h-5" />
+                  <EyeOff className="h-5 w-5" />
                 ) : (
-                  <Eye className="w-5 h-5" />
+                  <Eye className="h-5 w-5" />
                 )}
               </button>
             </div>
@@ -123,7 +133,7 @@ export default function Register({ onToggleLogin }: RegisterProps) {
           <button
             type="submit"
             disabled={loading || success}
-            className="w-full bg-green-600 text-white py-3 rounded-lg font-medium hover:bg-green-700 focus:ring-4 focus:ring-green-200 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            className="w-full rounded-lg bg-green-600 py-3 font-medium text-white transition-all hover:bg-green-700 focus:outline-none focus-visible:ring-4 focus-visible:ring-green-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-green-500 dark:hover:bg-green-400 dark:focus-visible:ring-green-500/40"
           >
             {loading ? 'Creating account...' : 'Create Account'}
           </button>
@@ -132,7 +142,7 @@ export default function Register({ onToggleLogin }: RegisterProps) {
         <div className="mt-6 text-center">
           <button
             onClick={onToggleLogin}
-            className="text-green-600 hover:text-green-700 font-medium text-sm transition-colors"
+            className="text-sm font-medium text-green-600 transition-colors hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
           >
             Already have an account? Sign in
           </button>

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,70 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  readonly theme: Theme;
+  readonly isDarkMode: boolean;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+interface ThemeProviderProps {
+  readonly children: ReactNode;
+}
+
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const storedTheme = window.localStorage.getItem('theme');
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    return storedTheme;
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+
+    try {
+      window.localStorage.setItem('theme', theme);
+    } catch (error) {
+      console.warn('Failed to persist theme preference', error);
+    }
+  }, [theme]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      isDarkMode: theme === 'dark',
+      toggleTheme: () => setThemeState((previous) => (previous === 'dark' ? 'light' : 'dark')),
+      setTheme: (nextTheme) => setThemeState(nextTheme)
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useThemeContext() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useThemeContext must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,5 @@
+import { useThemeContext } from '../contexts/ThemeContext';
+
+export function useTheme() {
+  return useThemeContext();
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-slate-100 text-slate-900 transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100;
+  }
+
+  select,
+  input,
+  textarea {
+    @apply transition-colors duration-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- introduce a shared theme context and wrap the app so users can switch between light and dark modes
- refresh login, registration, and dashboard styling to respect the dark theme, including a reusable toggle
- let admins preview stocktaker, manager, and admin dashboards by choosing a view and adjusting available navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e562534624832980bb35ee89ec7ea3